### PR TITLE
Add message copy arguments: reply_to_chat_id, quote_text, quote_entities

### DIFF
--- a/pyrogram/methods/messages/send_message.py
+++ b/pyrogram/methods/messages/send_message.py
@@ -34,6 +34,7 @@ class SendMessage:
         disable_web_page_preview: bool = None,
         disable_notification: bool = None,
         message_thread_id: int = None,
+        reply_to_chat_id: int = None,
         reply_to_message_id: int = None,
         reply_to_story_id: int = None,
         quote_text: str = None,
@@ -77,6 +78,9 @@ class SendMessage:
             message_thread_id (``int``, *optional*):
                 Unique identifier for the target message thread (topic) of the forum.
                 for forum supergroups only.
+
+            reply_to_chat_id (``int``, *optional*):
+                If the message is a reply, the ID of the original chat.
 
             reply_to_message_id (``int``, *optional*):
                 If the message is a reply, ID of the original message.
@@ -142,6 +146,10 @@ class SendMessage:
         quote_text, quote_entities = (await utils.parse_text_entities(self, quote_text, parse_mode, quote_entities)).values()
 
         peer = await self.resolve_peer(chat_id)
+        reply_to_peer = peer
+        if reply_to_chat_id:
+            reply_to_peer = await self.resolve_peer(reply_to_chat_id)
+
         r = await self.invoke(
             raw.functions.messages.SendMessage(
                 peer=peer,
@@ -150,7 +158,7 @@ class SendMessage:
                 reply_to=utils.get_reply_to(
                     reply_to_message_id=reply_to_message_id,
                     message_thread_id=message_thread_id,
-                    reply_to_peer=peer,
+                    reply_to_peer=reply_to_peer,
                     reply_to_story_id=reply_to_story_id,
                     quote_text=quote_text,
                     quote_entities=quote_entities,

--- a/pyrogram/methods/messages/send_message.py
+++ b/pyrogram/methods/messages/send_message.py
@@ -146,9 +146,8 @@ class SendMessage:
         quote_text, quote_entities = (await utils.parse_text_entities(self, quote_text, parse_mode, quote_entities)).values()
 
         peer = await self.resolve_peer(chat_id)
-        reply_to_peer = peer
         if reply_to_chat_id:
-            reply_to_peer = await self.resolve_peer(reply_to_chat_id)
+            peer = await self.resolve_peer(reply_to_chat_id)
 
         r = await self.invoke(
             raw.functions.messages.SendMessage(
@@ -158,7 +157,7 @@ class SendMessage:
                 reply_to=utils.get_reply_to(
                     reply_to_message_id=reply_to_message_id,
                     message_thread_id=message_thread_id,
-                    reply_to_peer=reply_to_peer,
+                    reply_to_peer=peer,
                     reply_to_story_id=reply_to_story_id,
                     quote_text=quote_text,
                     quote_entities=quote_entities,

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -3500,7 +3500,10 @@ class Message(Object, Update):
         caption_entities: List["types.MessageEntity"] = None,
         disable_notification: bool = None,
         message_thread_id: int = None,
+        reply_to_chat_id: int = None,
         reply_to_message_id: int = None,
+        quote_text: str = None,
+        quote_entities: List["types.MessageEntity"] = None,
         schedule_date: datetime = None,
         protect_content: bool = None,
         reply_markup: Union[
@@ -3553,8 +3556,17 @@ class Message(Object, Update):
                 Unique identifier for the target message thread (topic) of the forum.
                 for forum supergroups only.
 
+            reply_to_chat_id (``int``, *optional*):
+                If the message is a reply, ID of the original chat.
+
             reply_to_message_id (``int``, *optional*):
                 If the message is a reply, ID of the original message.
+
+            quote_text (``str``):
+                Text of the quote to be sent.
+
+            quote_entities (List of :obj:`~pyrogram.types.MessageEntity`):
+                List of special entities that appear in quote text, which can be specified instead of *parse_mode*.
 
             schedule_date (:py:obj:`~datetime.datetime`, *optional*):
                 Date when the message will be automatically sent.
@@ -3591,6 +3603,7 @@ class Message(Object, Update):
                 disable_web_page_preview=not self.web_page,
                 disable_notification=disable_notification,
                 message_thread_id=message_thread_id,
+                reply_to_chat_id=reply_to_chat_id,
                 reply_to_message_id=reply_to_message_id,
                 schedule_date=schedule_date,
                 protect_content=protect_content,
@@ -3603,6 +3616,8 @@ class Message(Object, Update):
                 disable_notification=disable_notification,
                 message_thread_id=message_thread_id,
                 reply_to_message_id=reply_to_message_id,
+                quote_text=quote_text,
+                quote_entities=quote_entities,
                 schedule_date=schedule_date,
                 protect_content=protect_content,
                 reply_markup=self.reply_markup if reply_markup is object else reply_markup


### PR DESCRIPTION
- methods.messages.send_message.SendMessage.send_message add argument "reply_to_chat_id"
- types.messages_and_media.message.Message.copy add arguments "reply_to_chat_id", "quote_text", "quote_entities"