### PR TITLE
Add FloodWait except to media download

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -802,6 +802,9 @@ class Client(Methods):
             if isinstance(e, asyncio.CancelledError):
                 raise e
 
+            if isinstance(e, pyrogram.errors.FloodWait):
+                raise e
+
             return None
         else:
             if in_memory:
@@ -1032,6 +1035,8 @@ class Client(Methods):
                     finally:
                         await cdn_session.stop()
             except pyrogram.StopTransmission:
+                raise
+            except pyrogram.errors.FloodWait:
                 raise
             except Exception as e:
                 log.exception(e)


### PR DESCRIPTION
Add FloodWait except to media download to handle this error from the script.

Before this change the exception would only be printed and the script would continue without a way to detect this error.

https://github.com/pyrogram/pyrogram/pull/1348