### PR TITLE
Fix session not getting saved to media_sessions in save_file method.

### DIFF
--- a/pyrogram/methods/advanced/save_file.py
+++ b/pyrogram/methods/advanced/save_file.py
@@ -143,7 +143,7 @@ class SaveFile:
 
             session = self.media_sessions.get(dc_id)
             if not session:
-                session = Session(
+                session = self.media_sessions[dc_id] = Session(
                     self, dc_id, await self.storage.auth_key(),
                     await self.storage.test_mode(), is_media=True
                 )


### PR DESCRIPTION
In `save_file` method, we end up opening a new `Session` to an alt dc if it already doesn't exist, but we never save it (cache it in the memory). So each time we end up opening a new session anyone (and we never manually close it either!).