### PR TITLE
Add `Str.html` and `Str.markdown` typing

### DIFF
--- a/pyrogram/parser/html.py
+++ b/pyrogram/parser/html.py
@@ -116,7 +116,7 @@ class HTML:
     def __init__(self, client: Optional["pyrogram.Client"]):
         self.client = client
 
-    async def parse(self, text: str):
+    async def parse(self, text: str) -> dict:
         # Strip whitespaces from the beginning and the end, but preserve closing tags
         text = re.sub(r"^\s*(<[\w<>=\s\"]*>)\s*", r"\1", text)
         text = re.sub(r"\s*(</[\w</>]*>)\s*$", r"\1", text)
@@ -154,7 +154,7 @@ class HTML:
         }
 
     @staticmethod
-    def unparse(text: str, entities: list):
+    def unparse(text: str, entities: list) -> str:
         def parse_one(entity):
             """
             Parses a single entity and returns (start_tag, start), (end_tag, end)

--- a/pyrogram/parser/parser.py
+++ b/pyrogram/parser/parser.py
@@ -30,8 +30,8 @@ class Parser:
         self.html = HTML(client)
         self.markdown = Markdown(client)
 
-    async def parse(self, text: str, mode: Optional[enums.ParseMode] = None):
-        text = str(text if text else "").strip()
+    async def parse(self, text: str, mode: Optional[enums.ParseMode] = None) -> dict:
+        text = str(text or "").strip()
 
         if mode is None:
             if self.client:
@@ -54,7 +54,7 @@ class Parser:
         raise ValueError(f'Invalid parse mode "{mode}"')
 
     @staticmethod
-    def unparse(text: str, entities: list, is_html: bool):
+    def unparse(text: str, entities: list, is_html: bool) -> str:
         if is_html:
             return HTML.unparse(text, entities)
         else:

--- a/pyrogram/parser/utils.py
+++ b/pyrogram/parser/utils.py
@@ -23,7 +23,7 @@ from struct import unpack
 SMP_RE = re.compile(r"[\U00010000-\U0010FFFF]")
 
 
-def add_surrogates(text):
+def add_surrogates(text: str) -> str:
     # Replace each SMP code point with a surrogate pair
     return SMP_RE.sub(
         lambda match:  # Split SMP in two surrogates
@@ -32,7 +32,7 @@ def add_surrogates(text):
     )
 
 
-def remove_surrogates(text):
+def remove_surrogates(text: str) -> str:
     # Replace each surrogate pair with a SMP code point
     return text.encode("utf-16", "surrogatepass").decode("utf-16")
 

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -37,22 +37,22 @@ class Str(str):
     def __init__(self, *args):
         super().__init__()
 
-        self.entities = None
+        self.entities: list = None
 
-    def init(self, entities):
+    def init(self, entities: list):
         self.entities = entities
 
         return self
 
     @property
-    def markdown(self):
+    def markdown(self) -> str:
         return Parser.unparse(self, self.entities, False)
 
     @property
-    def html(self):
+    def html(self) -> str:
         return Parser.unparse(self, self.entities, True)
 
-    def __getitem__(self, item):
+    def __getitem__(self, item) -> str:
         return parser_utils.remove_surrogates(parser_utils.add_surrogates(self)[item])
 
 


### PR DESCRIPTION
I would also be happy to indicate the return type of `Parser.parse` as `TypedDict`, but it was only introduced in 3.8.