### PR TITLE
add proper typehints to all of the pyrogram.methods.decorators classes

### DIFF
--- a/pyrogram/methods/decorators/on_callback_query.py
+++ b/pyrogram/methods/decorators/on_callback_query.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable
+from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
@@ -24,9 +24,9 @@ from pyrogram.filters import Filter
 
 class OnCallbackQuery:
     def on_callback_query(
-        self=None,
-        filters=None,
-        group: int = 0
+        self: Union["OnCallbackQuery", Filter, None] = None,
+        filters: Optional[Filter] = None,
+        group: int = 0,
     ) -> Callable:
         """Decorator for handling callback queries.
 

--- a/pyrogram/methods/decorators/on_chat_join_request.py
+++ b/pyrogram/methods/decorators/on_chat_join_request.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable
+from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
@@ -24,9 +24,9 @@ from pyrogram.filters import Filter
 
 class OnChatJoinRequest:
     def on_chat_join_request(
-        self=None,
-        filters=None,
-        group: int = 0
+        self: Union["OnChatJoinRequest", Filter, None] = None,
+        filters: Optional[Filter] = None,
+        group: int = 0,
     ) -> Callable:
         """Decorator for handling chat join requests.
 

--- a/pyrogram/methods/decorators/on_chat_member_updated.py
+++ b/pyrogram/methods/decorators/on_chat_member_updated.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable
+from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
@@ -24,9 +24,9 @@ from pyrogram.filters import Filter
 
 class OnChatMemberUpdated:
     def on_chat_member_updated(
-        self=None,
-        filters=None,
-        group: int = 0
+        self: Union["OnChatMemberUpdated", Filter, None] = None,
+        filters: Optional[Filter] = None,
+        group: int = 0,
     ) -> Callable:
         """Decorator for handling event changes on chat members.
 

--- a/pyrogram/methods/decorators/on_chosen_inline_result.py
+++ b/pyrogram/methods/decorators/on_chosen_inline_result.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable
+from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
@@ -24,9 +24,9 @@ from pyrogram.filters import Filter
 
 class OnChosenInlineResult:
     def on_chosen_inline_result(
-        self=None,
-        filters=None,
-        group: int = 0
+        self: Union["OnChosenInlineResult", Filter, None] = None,
+        filters: Optional[Filter] = None,
+        group: int = 0,
     ) -> Callable:
         """Decorator for handling chosen inline results.
 

--- a/pyrogram/methods/decorators/on_deleted_messages.py
+++ b/pyrogram/methods/decorators/on_deleted_messages.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable
+from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
@@ -24,9 +24,9 @@ from pyrogram.filters import Filter
 
 class OnDeletedMessages:
     def on_deleted_messages(
-        self=None,
-        filters=None,
-        group: int = 0
+        self: Union["OnDeletedMessages", Filter, None] = None,
+        filters: Optional[Filter] = None,
+        group: int = 0,
     ) -> Callable:
         """Decorator for handling deleted messages.
 

--- a/pyrogram/methods/decorators/on_disconnect.py
+++ b/pyrogram/methods/decorators/on_disconnect.py
@@ -16,13 +16,13 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable
+from typing import Callable, Optional
 
 import pyrogram
 
 
 class OnDisconnect:
-    def on_disconnect(self=None) -> Callable:
+    def on_disconnect(self: Optional["OnDisconnect"] = None) -> Callable:
         """Decorator for handling disconnections.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the

--- a/pyrogram/methods/decorators/on_edited_message.py
+++ b/pyrogram/methods/decorators/on_edited_message.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable
+from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
@@ -24,9 +24,9 @@ from pyrogram.filters import Filter
 
 class OnEditedMessage:
     def on_edited_message(
-        self=None,
-        filters=None,
-        group: int = 0
+        self: Union["OnEditedMessage", Filter, None] = None,
+        filters: Optional[Filter] = None,
+        group: int = 0,
     ) -> Callable:
         """Decorator for handling edited messages.
 

--- a/pyrogram/methods/decorators/on_inline_query.py
+++ b/pyrogram/methods/decorators/on_inline_query.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable
+from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
@@ -24,9 +24,9 @@ from pyrogram.filters import Filter
 
 class OnInlineQuery:
     def on_inline_query(
-        self=None,
-        filters=None,
-        group: int = 0
+        self: Union["OnInlineQuery", Filter, None] = None,
+        filters: Optional[Filter] = None,
+        group: int = 0,
     ) -> Callable:
         """Decorator for handling inline queries.
 

--- a/pyrogram/methods/decorators/on_message.py
+++ b/pyrogram/methods/decorators/on_message.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable
+from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
@@ -24,9 +24,9 @@ from pyrogram.filters import Filter
 
 class OnMessage:
     def on_message(
-        self=None,
-        filters=None,
-        group: int = 0
+        self: Union["OnMessage", Filter, None] = None,
+        filters: Optional[Filter] = None,
+        group: int = 0,
     ) -> Callable:
         """Decorator for handling new messages.
 

--- a/pyrogram/methods/decorators/on_poll.py
+++ b/pyrogram/methods/decorators/on_poll.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable
+from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
@@ -24,9 +24,9 @@ from pyrogram.filters import Filter
 
 class OnPoll:
     def on_poll(
-        self=None,
-        filters=None,
-        group: int = 0
+        self: Union["OnPoll", Filter, None] = None,
+        filters: Optional[Filter] = None,
+        group: int = 0,
     ) -> Callable:
         """Decorator for handling poll updates.
 

--- a/pyrogram/methods/decorators/on_raw_update.py
+++ b/pyrogram/methods/decorators/on_raw_update.py
@@ -16,15 +16,15 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable
+from typing import Callable, Optional
 
 import pyrogram
 
 
 class OnRawUpdate:
     def on_raw_update(
-        self=None,
-        group: int = 0
+        self: Optional["OnRawUpdate"] = None,
+        group: int = 0,
     ) -> Callable:
         """Decorator for handling raw updates.
 

--- a/pyrogram/methods/decorators/on_story.py
+++ b/pyrogram/methods/decorators/on_story.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable
+from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
@@ -24,9 +24,9 @@ from pyrogram.filters import Filter
 
 class OnStory:
     def on_story(
-        self=None,
-        filters=None,
-        group: int = 0
+        self: Union["OnStory", Filter, None] = None,
+        filters: Optional[Filter] = None,
+        group: int = 0,
     ) -> Callable:
         """Decorator for handling new stories.
 

--- a/pyrogram/methods/decorators/on_user_status.py
+++ b/pyrogram/methods/decorators/on_user_status.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable
+from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
@@ -24,9 +24,9 @@ from pyrogram.filters import Filter
 
 class OnUserStatus:
     def on_user_status(
-        self=None,
-        filters=None,
-        group: int = 0
+        self: Union["OnUserStatus", Filter, None] = None,
+        filters: Optional[Filter] = None,
+        group: int = 0,
     ) -> Callable:
         """Decorator for handling user status updates.
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the


### PR DESCRIPTION

# The issue:
mypy (as well as PyLance) is complaining when @Client.on_... is used w/ filters

Reproducing:
create a `test.py` file
```python
from pyrogram import filters, Client

@Client.on_message(filters.private)
async def test(client, message) -> None:
    pass
```

check it w/ mypy:
```bash
mypy test.py
```

the output is:
```
test.py:3: error: Argument 1 to "on_message" of "OnMessage" has incompatible type "Filter"; expected "OnMessage"  [arg-type]
Found 1 error in 1 file (checked 1 source file)
```

it's caused by the lack of typehints in OnMessage and similar classes from pyrogram.methods.decorators:
```python
class OnMessage:
    def on_message(
        self=None, # ⬅️ HERE
        filters=None, # ⬅️ HERE
        group: int = 0
    ) -> Callable:
```

# the applied fix:
```python
class OnMessage:
    def on_message(
        self: Union["OnMessage", Filter, None] = None,
        filters: Optional[Filter] = None,
        group: int = 0,
    ) -> Callable:
```

# verification w/ mypy:
```
Success: no issues found in 1 source file
```