### PR TITLE
Add fallback parameter to set_profile_photo and minor fixes

### DIFF
--- a/pyrogram/methods/chats/get_forum_topics_by_id.py
+++ b/pyrogram/methods/chats/get_forum_topics_by_id.py
@@ -70,12 +70,18 @@ class GetForumTopicsByID:
             )
         )
 
-        users = {i.id: i for i in r.users}
-        chats = {i.id: i for i in r.chats}
-
         topics = types.List()
+        users = {u.id: u for u in getattr(r, "users", [])}
+        chats = {c.id: c for c in getattr(r, "chats", [])}
+        messages = {m.id: m for m in getattr(r, "messages", [])}
 
-        for i in r.topics:
-            topics.append(types.ForumTopic._parse(self, i, users=users, chats=chats))
+        for current in getattr(r, "topics", []):
+            topics.append(types.ForumTopic._parse(
+                self, 
+                forum_topic=current,
+                messages=messages,
+                users=users, 
+                chats=chats
+            ))
 
         return topics if is_iterable else topics[0] if topics else None

--- a/pyrogram/methods/chats/get_forum_topics_by_id.py
+++ b/pyrogram/methods/chats/get_forum_topics_by_id.py
@@ -70,18 +70,12 @@ class GetForumTopicsByID:
             )
         )
 
-        topics = types.List()
-        users = {u.id: u for u in getattr(r, "users", [])}
-        chats = {c.id: c for c in getattr(r, "chats", [])}
-        messages = {m.id: m for m in getattr(r, "messages", [])}
+        users = {i.id: i for i in r.users}
+        chats = {i.id: i for i in r.chats}
 
-        for current in getattr(r, "topics", []):
-            topics.append(types.ForumTopic._parse(
-                self, 
-                forum_topic=current,
-                messages=messages,
-                users=users, 
-                chats=chats
-            ))
+        topics = types.List()
+
+        for i in r.topics:
+            topics.append(types.ForumTopic._parse(self, i, users=users, chats=chats))
 
         return topics if is_iterable else topics[0] if topics else None

--- a/pyrogram/methods/chats/promote_chat_member.py
+++ b/pyrogram/methods/chats/promote_chat_member.py
@@ -87,7 +87,7 @@ class PromoteChatMember:
                     post_messages=privileges.can_post_messages,
                     post_stories=privileges.can_post_stories,
                     edit_messages=privileges.can_edit_messages,
-                    edit_stories=privileges.can_post_stories,
+                    edit_stories=privileges.can_edit_stories,
                     delete_messages=privileges.can_delete_messages,
                     delete_stories=privileges.can_delete_stories,
                     ban_users=privileges.can_restrict_members,

--- a/pyrogram/methods/messages/download_media.py
+++ b/pyrogram/methods/messages/download_media.py
@@ -104,6 +104,9 @@ class DownloadMedia:
                 # Download from file id
                 await app.download_media(message.photo.file_id)
 
+                # Download document of a message
+                await app.download_media(message.document)
+
                 # Keep track of the progress while downloading
                 async def progress(current, total):
                     print(f"{current * 100 / total:.1f}%")
@@ -138,6 +141,8 @@ class DownloadMedia:
             media = getattr(message, message.media.value, None)
         elif isinstance(message, str):
             media = message
+        elif hasattr(message, "file_id"):
+            media = getattr(message, "file_id")
 
         if not media:
             raise ValueError("This message doesn't contain any downloadable media")

--- a/pyrogram/methods/users/set_profile_photo.py
+++ b/pyrogram/methods/users/set_profile_photo.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, BinaryIO
+from typing import Union, BinaryIO, Optional
 
 import pyrogram
 from pyrogram import raw
@@ -26,6 +26,7 @@ class SetProfilePhoto:
     async def set_profile_photo(
         self: "pyrogram.Client",
         *,
+        fallback: Optional[bool] = None,
         photo: Union[str, BinaryIO] = None,
         video: Union[str, BinaryIO] = None
     ) -> bool:
@@ -42,6 +43,11 @@ class SetProfilePhoto:
         .. include:: /_includes/usable-by/users.rst
 
         Parameters:
+            fallback (``bool``, *optional*):
+                If set to True, the chosen profile photo will be shown to users that can't display
+                your main profile photo due to your privacy settings.
+                Defaults to None.
+
             photo (``str`` | ``BinaryIO``, *optional*):
                 Profile photo to set.
                 Pass a file path as string to upload a new photo that exists on your local machine or
@@ -61,6 +67,9 @@ class SetProfilePhoto:
                 # Set a new profile photo
                 await app.set_profile_photo(photo="new_photo.jpg")
 
+                # Set/update your account's public profile photo
+                await app.set_profile_photo(fallback=True, photo="new_photo.jpg")
+
                 # Set a new profile video
                 await app.set_profile_photo(video="new_video.mp4")
         """
@@ -68,6 +77,7 @@ class SetProfilePhoto:
         return bool(
             await self.invoke(
                 raw.functions.photos.UploadProfilePhoto(
+                    fallback=fallback,
                     file=await self.save_file(photo),
                     video=await self.save_file(video)
                 )

--- a/pyrogram/methods/users/set_profile_photo.py
+++ b/pyrogram/methods/users/set_profile_photo.py
@@ -26,9 +26,9 @@ class SetProfilePhoto:
     async def set_profile_photo(
         self: "pyrogram.Client",
         *,
-        fallback: Optional[bool] = None,
-        photo: Union[str, BinaryIO] = None,
-        video: Union[str, BinaryIO] = None
+        photo: Optional[Union[str, BinaryIO]] = None,
+        video: Optional[Union[str, BinaryIO]] = None,
+        is_public: Optional[bool] = None
     ) -> bool:
         """Set a new profile photo or video (H.264/MPEG-4 AVC video, max 5 seconds).
 
@@ -43,11 +43,6 @@ class SetProfilePhoto:
         .. include:: /_includes/usable-by/users.rst
 
         Parameters:
-            fallback (``bool``, *optional*):
-                If set to True, the chosen profile photo will be shown to users that can't display
-                your main profile photo due to your privacy settings.
-                Defaults to None.
-
             photo (``str`` | ``BinaryIO``, *optional*):
                 Profile photo to set.
                 Pass a file path as string to upload a new photo that exists on your local machine or
@@ -58,6 +53,11 @@ class SetProfilePhoto:
                 Pass a file path as string to upload a new video that exists on your local machine or
                 pass a binary file-like object with its attribute ".name" set for in-memory uploads.
 
+            is_public (``bool``, *optional*):
+                If set to True, the chosen profile photo will be shown to users that can't display
+                your main profile photo due to your privacy settings.
+                Defaults to None.
+
         Returns:
             ``bool``: True on success.
 
@@ -67,17 +67,17 @@ class SetProfilePhoto:
                 # Set a new profile photo
                 await app.set_profile_photo(photo="new_photo.jpg")
 
-                # Set/update your account's public profile photo
-                await app.set_profile_photo(fallback=True, photo="new_photo.jpg")
-
                 # Set a new profile video
                 await app.set_profile_photo(video="new_video.mp4")
+
+                # Set/update your account's public profile photo
+                await app.set_profile_photo(photo="new_photo.jpg", is_public=True)
         """
 
         return bool(
             await self.invoke(
                 raw.functions.photos.UploadProfilePhoto(
-                    fallback=fallback,
+                    fallback=is_public,
                     file=await self.save_file(photo),
                     video=await self.save_file(video)
                 )

--- a/pyrogram/types/inline_mode/inline_query_result_animation.py
+++ b/pyrogram/types/inline_mode/inline_query_result_animation.py
@@ -144,7 +144,7 @@ class InlineQueryResultAnimation(InlineQueryResult):
             thumb=thumb,
             content=animation,
             send_message=(
-                self.input_message_content.write(client, self.reply_markup)
+                await self.input_message_content.write(client, self.reply_markup)
                 if self.input_message_content
                 else raw.types.InputBotInlineMessageMediaAuto(
                     reply_markup=await self.reply_markup.write(client) if self.reply_markup else None,


### PR DESCRIPTION
This pull request applies following patches to the code:
1. The method `get_forum_topics_by_id` was giving me attribute errors for some time, so instead of accessing attributes directly, I made it use `getattr` (e.g. `getattr(r, "messages", [])`); so it doesn't raise attribute errors anymore.
Been testing this on my own fork and been working fine for a while.
Also `ForumTopic._parse` does indeed need `messages` parameters to get passed to it (so it can later on use `top_message` (int32) from its raw type to fetch the top message from the messages we have provided it)... (previously we were passing `messages` parameter to this method as well, but in a recent commit, this got removed).

2. The `promote_chat_member` method was using `edit_stories=privileges.can_post_stories`, which is wrong.

3. `inline_query_result_animation` is using `input_message_content.write` method (which is an async method) without using `await` keyword. (For proof you can check other inline query result types, such as [audio](https://github.com/KurimuzonAkuma/pyrogram/blob/50dbfd33fe1647df7e7841f263d7b6e56fb51532/pyrogram/types/inline_mode/inline_query_result_audio.py#L112); all of them are using `await` for `.write` method.

4. Official clients have the ability to upload something called "Public Profile Photo":
![image](https://github.com/KurimuzonAkuma/pyrogram/assets/70187458/d4dd91f6-93d6-4340-bfc9-96dfa31b8449)

In MTProto, that's literally possible by passing a bool parameter called `fallback` to `set_profile_photo`.

5. There is a bug in `download_media`  that is caused by recent commits; whereas the method does not check for `file_id` field (e.g. when `message.document` is passed to the method) and hence will raise exception. This was working fine in previous versions.