### PR TITLE
Added on_startup and on_shutdown for run(), start(), stop() and compose()

### DIFF
--- a/pyrogram/methods/utilities/run.py
+++ b/pyrogram/methods/utilities/run.py
@@ -47,6 +47,18 @@ class Run:
             coroutine (``Coroutine``, *optional*):
                 Pass a coroutine to run it until it completes.
 
+            on_startup (``callable``, *optional*):
+                Function to execute when client is started.
+
+            on_shutdown (``callable``, *optional*):
+                Function to execute on client's shutdown.
+
+            NOTE: 
+                You can use client methods in on_startup and on_shutdown
+                functions only if you're not specifying a coroutine in run()
+                since new functions run only before coroutine (it means before client is authorized)
+                and after It's finished (after client is terminated).
+
         Raises:
             ConnectionError: In case you try to run an already started client.
 

--- a/pyrogram/methods/utilities/run.py
+++ b/pyrogram/methods/utilities/run.py
@@ -18,6 +18,7 @@
 
 import asyncio
 import inspect
+from typing import Callable, Any, Awaitable
 
 import pyrogram
 from pyrogram.methods.utilities.idle import idle
@@ -26,7 +27,9 @@ from pyrogram.methods.utilities.idle import idle
 class Run:
     def run(
         self: "pyrogram.Client",
-        coroutine=None
+        coroutine: Callable[[Any, Any], Awaitable[Any]] = None,
+        on_startup: Callable[[Any, Any], Awaitable[Any]] = None,
+        on_shutdown: Callable[[Any, Any], Awaitable[Any]] = None
     ):
         """Start the client, idle the main script and finally stop the client.
 
@@ -74,13 +77,17 @@ class Run:
         run = loop.run_until_complete
 
         if coroutine is not None:
+            if on_startup:
+                run(on_startup())
             run(coroutine)
+            if on_shutdown:
+                run(on_shutdown())
         else:
             if inspect.iscoroutinefunction(self.start):
-                run(self.start())
+                run(self.start(on_startup=on_startup))
                 run(idle())
-                run(self.stop())
+                run(self.stop(on_shutdown=on_shutdown))
             else:
-                self.start()
+                self.start(on_startup=on_startup)
                 run(idle())
-                self.stop()
+                self.stop(on_shutdown=on_shutdown)

--- a/pyrogram/methods/utilities/start.py
+++ b/pyrogram/methods/utilities/start.py
@@ -35,6 +35,10 @@ class Start:
         This method connects the client to Telegram and, in case of new sessions, automatically manages the
         authorization process using an interactive prompt.
 
+        Parameters:
+            on_startup (``callable``, *optional*):
+                Function to execute when client is started.
+
         Returns:
             :obj:`~pyrogram.Client`: The started client itself.
 

--- a/pyrogram/methods/utilities/start.py
+++ b/pyrogram/methods/utilities/start.py
@@ -17,6 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+from typing import Callable, Any, Awaitable
 
 import pyrogram
 from pyrogram import raw
@@ -26,7 +27,8 @@ log = logging.getLogger(__name__)
 
 class Start:
     async def start(
-        self: "pyrogram.Client"
+        self: "pyrogram.Client",
+        on_startup: Callable[[Any, Any], Awaitable[Any]] = None
     ):
         """Start the client.
 
@@ -64,6 +66,9 @@ class Start:
             if not await self.storage.is_bot() and self.takeout:
                 self.takeout_id = (await self.invoke(raw.functions.account.InitTakeoutSession())).id
                 log.info("Takeout session %s initiated", self.takeout_id)
+
+            if on_startup:
+                await on_startup()
 
             await self.invoke(raw.functions.updates.GetState())
         except (Exception, KeyboardInterrupt):

--- a/pyrogram/methods/utilities/stop.py
+++ b/pyrogram/methods/utilities/stop.py
@@ -36,6 +36,9 @@ class Stop:
                 Blocks the code execution until the client has been stopped. It is useful with ``block=False`` in case
                 you want to stop the own client *within* a handler in order not to cause a deadlock.
                 Defaults to True.
+                
+            on_shutdown (``callable``, *optional*):
+                Function to execute on client's shutdown.
 
         Returns:
             :obj:`~pyrogram.Client`: The stopped client itself.

--- a/pyrogram/methods/utilities/stop.py
+++ b/pyrogram/methods/utilities/stop.py
@@ -16,13 +16,16 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Callable, Any, Awaitable
+
 import pyrogram
 
 
 class Stop:
     async def stop(
         self: "pyrogram.Client",
-        block: bool = True
+        block: bool = True,
+        on_shutdown: Callable[[Any, Any], Awaitable[Any]] = None
     ):
         """Stop the Client.
 
@@ -58,6 +61,8 @@ class Stop:
         """
 
         async def do_it():
+            if on_shutdown:
+                await on_shutdown()
             await self.terminate()
             await self.disconnect()
 


### PR DESCRIPTION
**Note:** You can use client methods in on_startup and on_shutdown functions only if you're not specifying a coroutine in run() since new functions run only before coroutine (it means before client is authorized) and after It's finished (after client is terminated).


Example with coroutine specified (you **CAN'T** use app (client) in new functions):

```python3
...
app = Client(...)

async def main():
    async with app:
        me = await app.get_me()
        print(f"App initialized only now, {me.first_name}!")


async def on_startup():
    print("Client is running!")


async def on_shutdown():
    print("Goodbye!")


app.run(main(), on_startup=on_startup, on_shutdown=on_shutdown)

```

Example without coroutine (you **CAN** use app (client) in new functions bc app is already running):

```python3
...
app = Client(...)

async def on_startup():
    me = await app.get_me()
    print(f"Welcome, {me.first_name}!")


async def on_shutdown():
    me = await app.get_me()
    print(f"Goodbye, {me.first_name}!")


app.run(on_startup=on_startup, on_shutdown=on_shutdown)

```
