### PR TITLE
Add min_id and max_id arguments to get_chat_history method

### DIFF
--- a/pyrogram/methods/messages/get_chat_history.py
+++ b/pyrogram/methods/messages/get_chat_history.py
@@ -30,7 +30,9 @@ async def get_chunk(
     limit: int = 0,
     offset: int = 0,
     from_message_id: int = 0,
-    from_date: datetime = utils.zero_datetime()
+    from_date: datetime = utils.zero_datetime(),
+    min_id: int = 0,
+    max_id: int = 0
 ):
     messages = await client.invoke(
         raw.functions.messages.GetHistory(
@@ -39,8 +41,8 @@ async def get_chunk(
             offset_date=utils.datetime_to_timestamp(from_date),
             add_offset=offset,
             limit=limit,
-            max_id=0,
-            min_id=0,
+            max_id=max_id,
+            min_id=min_id,
             hash=0
         ),
         sleep_threshold=60
@@ -56,7 +58,9 @@ class GetChatHistory:
         limit: int = 0,
         offset: int = 0,
         offset_id: int = 0,
-        offset_date: datetime = utils.zero_datetime()
+        offset_date: datetime = utils.zero_datetime(),
+        min_id: int = 0,
+        max_id: int = 0
     ) -> AsyncGenerator["types.Message", None]:
         """Get messages from a chat history.
 
@@ -84,6 +88,12 @@ class GetChatHistory:
             offset_date (:py:obj:`~datetime.datetime`, *optional*):
                 Pass a date as offset to retrieve only older messages starting from that date.
 
+            min_id (``int``, *optional*):
+                If a positive value was transferred, the method will return only messages with IDs more than min_id
+
+            max_id (``int``, *optional*):
+                If a positive value was transferred, the method will return only messages with IDs less than max_id
+
         Returns:
             ``Generator``: A generator yielding :obj:`~pyrogram.types.Message` objects.
 
@@ -104,7 +114,9 @@ class GetChatHistory:
                 limit=limit,
                 offset=offset,
                 from_message_id=offset_id,
-                from_date=offset_date
+                from_date=offset_date,
+                min_id=min_id,
+                max_id=max_id
             )
 
             if not messages:

--- a/pyrogram/methods/messages/get_chat_history.py
+++ b/pyrogram/methods/messages/get_chat_history.py
@@ -89,10 +89,10 @@ class GetChatHistory:
                 Pass a date as offset to retrieve only older messages starting from that date.
 
             min_id (``int``, *optional*):
-                If a positive value was transferred, the method will return only messages with IDs more than min_id
+                If a positive value was provided, the method will return only messages with IDs more than min_id.
 
             max_id (``int``, *optional*):
-                If a positive value was transferred, the method will return only messages with IDs less than max_id
+                If a positive value was provided, the method will return only messages with IDs less than max_id.
 
         Returns:
             ``Generator``: A generator yielding :obj:`~pyrogram.types.Message` objects.


### PR DESCRIPTION
These arguments is useful if you want to retrieve only new messages from channel (min_id should be set as last retrieved message id)