### PR TITLE
Fix: edge-case when pinned action is `MessageActionHistoryClear`

### DIFF
--- a/pyrogram/enums/chat_event_action.py
+++ b/pyrogram/enums/chat_event_action.py
@@ -123,6 +123,10 @@ class ChatEventAction(AutoName):
     MESSAGE_UNPINNED = auto()
     "a message has been unpinned (see ``unpinned_message``)"
 
+    MESSAGE_PIN_CHANGED = auto()
+    "a message has been pinned or unpinned but actual message is not received"
+    "should never be used in end-user code, only for correct parsing"
+
     CREATED_FORUM_TOPIC = auto()
     "a new forum topic has been created (see `created_forum_topic`)"
 
@@ -131,9 +135,6 @@ class ChatEventAction(AutoName):
 
     DELETED_FORUM_TOPIC = auto()
     "a forum topic has been deleted (see `deleted_forum_topic`)"
-
-    HISTORY_CLEARED = auto()
-    "the chat history has been cleared (see `MessageActionHistoryClear`)"
 
     UNKNOWN = auto()
     "Unknown chat event action"

--- a/pyrogram/enums/chat_event_action.py
+++ b/pyrogram/enums/chat_event_action.py
@@ -132,5 +132,8 @@ class ChatEventAction(AutoName):
     DELETED_FORUM_TOPIC = auto()
     "a forum topic has been deleted (see `deleted_forum_topic`)"
 
+    HISTORY_CLEARED = auto()
+    "the chat history has been cleared (see `MessageActionHistoryClear`)"
+
     UNKNOWN = auto()
     "Unknown chat event action"

--- a/pyrogram/types/user_and_chats/chat_event.py
+++ b/pyrogram/types/user_and_chats/chat_event.py
@@ -433,12 +433,16 @@ class ChatEvent(Object):
         elif isinstance(action, raw.types.ChannelAdminLogEventActionUpdatePinned):
             message = action.message
 
-            if message.pinned:
+            if isinstance(message, raw.types.Message) and message.pinned:
                 pinned_message = await types.Message._parse(client, message, users, chats)
                 action = enums.ChatEventAction.MESSAGE_PINNED
-            else:
+            elif isinstance(message, raw.types.Message) and not message.pinned:
                 unpinned_message = await types.Message._parse(client, message, users, chats)
                 action = enums.ChatEventAction.MESSAGE_UNPINNED
+            elif isinstance(message, raw.types.MessageService) and isinstance(message.action, raw.types.MessageActionHistoryClear):
+                action = enums.ChatEventAction.HISTORY_CLEARED
+            else:
+                action = f"{enums.ChatEventAction.UNKNOWN}-{action.QUALNAME}"
 
         elif isinstance(action, raw.types.ChannelAdminLogEventActionExportedInviteEdit):
             old_invite_link = types.ChatInviteLink._parse(client, action.prev_invite, users)

--- a/pyrogram/types/user_and_chats/chat_event.py
+++ b/pyrogram/types/user_and_chats/chat_event.py
@@ -439,10 +439,8 @@ class ChatEvent(Object):
             elif isinstance(message, raw.types.Message) and not message.pinned:
                 unpinned_message = await types.Message._parse(client, message, users, chats)
                 action = enums.ChatEventAction.MESSAGE_UNPINNED
-            elif isinstance(message, raw.types.MessageService) and isinstance(message.action, raw.types.MessageActionHistoryClear):
-                action = enums.ChatEventAction.HISTORY_CLEARED
             else:
-                action = f"{enums.ChatEventAction.UNKNOWN}-{action.QUALNAME}"
+                action = enums.ChatEventAction.MESSAGE_PIN_CHANGED
 
         elif isinstance(action, raw.types.ChannelAdminLogEventActionExportedInviteEdit):
             old_invite_link = types.ChatInviteLink._parse(client, action.prev_invite, users)


### PR DESCRIPTION
Fix edge-case when pinned action message is `MessageActionHistoryClear`.

What I received inside raw action:

```python
action <class 'pyrogram.raw.types.channel_admin_log_event_action_update_pinned.ChannelAdminLogEventActionUpdatePinned'> 
pyrogram.raw.types.ChannelAdminLogEventActionUpdatePinned(
  message=pyrogram.raw.types.MessageService(
    id=1337, 
    peer_id=pyrogram.raw.types.PeerChannel(channel_id=1337), 
    date=1714411215, 
    action=pyrogram.raw.types.MessageActionHistoryClear(), 
    out=True, 
    mentioned=False, 
    media_unread=False, 
    silent=False, 
    post=False, 
    legacy=False, 
    from_id=pyrogram.raw.types.PeerUser(user_id=1337)
  )
)
```

Error before following commit:
```python
Traceback (most recent call last):
  File "D:\Code\Personal\userbot\scripts\testing.py", line 57, in <module>
    loop.run_until_complete(main())
  File "C:\Program Files\Python310\lib\asyncio\base_events.py", line 649, in run_until_complete
    return future.result()
  File "D:\Code\Personal\userbot\scripts\testing.py", line 41, in main
    async for action in client.get_chat_event_log(chat_id):
  File "D:\Code\Personal\userbot\.venv\lib\site-packages\pyrogram\methods\chats\get_chat_event_log.py", line 104, in get_chat_event_log
    yield await types.ChatEvent._parse(self, event, r.users, r.chats)
  File "D:\Code\Personal\userbot\.venv\lib\site-packages\pyrogram\types\user_and_chats\chat_event.py", line 436, in _parse
    if message.pinned:
AttributeError: 'MessageService' object has no attribute 'pinned'

Process finished with exit code 1

```