### PR TITLE
Fix sending no-sound videos in media group & sending media as videos by default in `send_video`

### DIFF
--- a/pyrogram/methods/messages/send_media_group.py
+++ b/pyrogram/methods/messages/send_media_group.py
@@ -213,7 +213,7 @@ class SendMediaGroup:
                                     thumb=await self.save_file(i.thumb),
                                     spoiler=i.has_spoiler,
                                     mime_type=self.guess_mime_type(i.media) or "video/mp4",
-                                    nosound_video=i.no_sound,
+                                    nosound_video=True,
                                     attributes=[
                                         raw.types.DocumentAttributeVideo(
                                             supports_streaming=i.supports_streaming or None,
@@ -267,7 +267,7 @@ class SendMediaGroup:
                                 thumb=await self.save_file(i.thumb),
                                 spoiler=i.has_spoiler,
                                 mime_type=self.guess_mime_type(getattr(i.media, "name", "video.mp4")) or "video/mp4",
-                                nosound_video=i.no_sound,
+                                nosound_video=True,
                                 attributes=[
                                     raw.types.DocumentAttributeVideo(
                                         supports_streaming=i.supports_streaming or None,

--- a/pyrogram/methods/messages/send_video.py
+++ b/pyrogram/methods/messages/send_video.py
@@ -57,7 +57,7 @@ class SendVideo:
         quote_offset: int = None,
         schedule_date: datetime = None,
         protect_content: bool = None,
-        no_sound: bool = None,
+        no_sound: bool = True,
         business_connection_id: str = None,
         reply_markup: Union[
             "types.InlineKeyboardMarkup",


### PR DESCRIPTION
Requirements: we have video without sound named 'test.mp4'.

Without this PR, the following code fails:
```python
async with client:
    media = [
        types.InputMediaVideo(media="test.mp4"),
        types.InputMediaVideo(media="test.mp4"),
    ]
    await client.send_media_group(chat_id="me", media=media)
```

with error:
```
Traceback (most recent call last):
  File "D:\Code\Personal\pyrogram\check.py", line 49, in <module>
    loop.run_until_complete(main())
  File "C:\Program Files\Python310\lib\asyncio\base_events.py", line 649, in run_until_complete
    return future.result()
  File "D:\Code\Personal\pyrogram\check.py", line 36, in main
    await client.send_media_group(
  File "D:\Code\Personal\pyrogram\src\pyrogram\methods\messages\send_media_group.py", line 455, in send_media_group
    r = await self.invoke(
  File "D:\Code\Personal\pyrogram\src\pyrogram\methods\advanced\invoke.py", line 94, in invoke
    r = await session.invoke(
  File "D:\Code\Personal\pyrogram\src\pyrogram\session\session.py", line 401, in invoke
    return await self.send(query, timeout=timeout)
  File "D:\Code\Personal\pyrogram\src\pyrogram\session\session.py", line 369, in send
    RPCError.raise_it(result, type(data))
  File "D:\Code\Personal\pyrogram\src\pyrogram\errors\rpc_error.py", line 91, in raise_it
    raise getattr(
pyrogram.errors.exceptions.bad_request_400.MediaEmpty: Telegram says: [400 MEDIA_EMPTY] - The media you tried to send is invalid (caused by "messages.SendMultiMedia")
```

Because GIF media (actually called 'animated') can not be sent in media group.
This PR changes it, so all valid files in media groups actually can be sent.

I also changed default `no_sound` for `send_video`, because currently it sends no-sound videos as GIFs, which is not expected.
