### PR TITLE
fix: type annotation on `Message.reply_document`

### DIFF
--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -2031,7 +2031,7 @@ class Message(Object, Update):
         self,
         document: Union[str, BinaryIO],
         quote: bool = None,
-        thumb: str = None,
+        thumb: Union[str, BinaryIO] = None,
         caption: str = "",
         parse_mode: Optional["enums.ParseMode"] = None,
         caption_entities: List["types.MessageEntity"] = None,
@@ -2083,7 +2083,7 @@ class Message(Object, Update):
                 If *reply_to_message_id* is passed, this parameter will be ignored.
                 Defaults to ``True`` in group chats and ``False`` in private chats.
 
-            thumb (``str``, *optional*):
+            thumb (``str`` | ``BinaryIO``, *optional*):
                 Thumbnail of the file sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.


### PR DESCRIPTION
this method is a bound method for `Client.send_document`, where its type annotation for `thumb` is `Union[str, BinaryIO]`

therefore, the type annotation in `Message.reply_document` should not differ