### PR TITLE
fill me attribute on connect method

### DIFF
--- a/pyrogram/methods/auth/connect.py
+++ b/pyrogram/methods/auth/connect.py
@@ -48,4 +48,9 @@ class Connect:
 
         self.is_connected = True
 
-        return bool(await self.storage.user_id())
+        r = bool(await self.storage.user_id())
+
+        if r:
+            self.me = await self.get_me()
+
+        return r


### PR DESCRIPTION
This pr to fix this error:
```
  File "C:\Users\W6659\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\pyrogram\methods\advanced\save_file.py", line 131, in save_file
    file_size_limit_mib = 4000 if self.me.is_premium else 2000
                                  ^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'is_premium'
```

**https://t.me/kurigram_chat/43769**, **https://t.me/RuPyrogram/1/382220**, **https://t.me/MayuriChan_Chat/3643**, **https://t.me/PyrogramChatAR/15297**,  and it's reported by @Wael6659 too.
