### PR TITLE
Fix incorrect return type for start_bot method.

### DIFF
--- a/pyrogram/methods/messages/start_bot.py
+++ b/pyrogram/methods/messages/start_bot.py
@@ -28,7 +28,7 @@ class StartBot:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         param: str = ""
-    ) -> bool:
+    ) -> "types.Message":
         """Start bot
 
         .. include:: /_includes/usable-by/users.rst


### PR DESCRIPTION
The `start_bot` method in `pyrogram.Client.start_bot` was incorrectly annotated to return `bool`, but it returns an instance of `pyrogram.types.Message`. This PR corrects the return type annotation to `Message`.