### PR TITLE
Fix create release step in github workflow.

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -33,7 +33,7 @@ jobs:
           password: ${{ secrets.PYPI_API_TOKEN }}
       - name: Set the Version
         run: |
-          grep_result=$(grep version pyrogram/__init__.py)
+          grep_result=$(grep -E '__version__ = ".*"' pyrogram/__init__.py)
           prefix="__version__ = \""
           suffix="\""
           final_value=${grep_result#"$prefix"}


### PR DESCRIPTION
This pull request fixes the grep command used in the github workflow to create a new release.