### PR TITLE
feat: extend `show_caption_above_media` to applicable methods

### DIFF
--- a/pyrogram/methods/messages/copy_message.py
+++ b/pyrogram/methods/messages/copy_message.py
@@ -42,6 +42,7 @@ class CopyMessage:
         schedule_date: datetime = None,
         protect_content: bool = None,
         has_spoiler: bool = None,
+        show_caption_above_media: bool = None,
         business_connection_id: str = None,
         allow_paid_broadcast: bool = None,
         reply_markup: Union[
@@ -107,6 +108,9 @@ class CopyMessage:
             has_spoiler (``bool``, *optional*):
                 True, if the message media is covered by a spoiler animation.
 
+            show_caption_above_media (``bool``, *optional*):
+                If True, caption must be shown above the message media.
+            
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
 
@@ -138,6 +142,7 @@ class CopyMessage:
             schedule_date=schedule_date,
             protect_content=protect_content,
             has_spoiler=has_spoiler,
+            show_caption_above_media=show_caption_above_media,
             allow_paid_broadcast=allow_paid_broadcast,
             reply_markup=reply_markup,
             business_connection_id=business_connection_id

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -1586,6 +1586,7 @@ class Message(Object, Update):
         parse_mode: Optional["enums.ParseMode"] = None,
         caption_entities: List["types.MessageEntity"] = None,
         has_spoiler: bool = None,
+        show_caption_above_media: bool = None,
         duration: int = 0,
         width: int = 0,
         height: int = 0,
@@ -1647,6 +1648,9 @@ class Message(Object, Update):
 
             has_spoiler (``bool``, *optional*):
                 Pass True if the animation needs to be covered with a spoiler animation.
+
+            show_caption_above_media (``bool``, *optional*):
+                Pass True, if the caption must be shown above the message media.
 
             duration (``int``, *optional*):
                 Duration of sent animation in seconds.
@@ -1746,6 +1750,7 @@ class Message(Object, Update):
             parse_mode=parse_mode,
             caption_entities=caption_entities,
             has_spoiler=has_spoiler,
+            show_caption_above_media=show_caption_above_media,
             duration=duration,
             width=width,
             height=height,
@@ -2849,6 +2854,7 @@ class Message(Object, Update):
         parse_mode: Optional["enums.ParseMode"] = None,
         caption_entities: List["types.MessageEntity"] = None,
         has_spoiler: bool = None,
+        show_caption_above_media: bool = None,
         ttl_seconds: int = None,
         disable_notification: bool = None,
         message_thread_id: int = None,
@@ -2908,6 +2914,9 @@ class Message(Object, Update):
 
             has_spoiler (``bool``, *optional*):
                 Pass True if the photo needs to be covered with a spoiler animation.
+
+            show_caption_above_media (``bool``, *optional*):
+                Pass True, if the caption must be shown above the message media.
 
             ttl_seconds (``int``, *optional*):
                 Self-Destruct Timer.
@@ -3001,6 +3010,7 @@ class Message(Object, Update):
             parse_mode=parse_mode,
             caption_entities=caption_entities,
             has_spoiler=has_spoiler,
+            show_caption_above_media=show_caption_above_media,
             ttl_seconds=ttl_seconds,
             disable_notification=disable_notification,
             message_thread_id=message_thread_id,
@@ -3546,6 +3556,7 @@ class Message(Object, Update):
         parse_mode: Optional["enums.ParseMode"] = None,
         caption_entities: List["types.MessageEntity"] = None,
         has_spoiler: bool = None,
+        show_caption_above_media: bool = None,
         ttl_seconds: int = None,
         duration: int = 0,
         width: int = 0,
@@ -3610,6 +3621,9 @@ class Message(Object, Update):
 
             has_spoiler (``bool``, *optional*):
                 Pass True if the video needs to be covered with a spoiler animation.
+
+            show_caption_above_media (``bool``, *optional*):
+                Pass True to show the video caption above the video.
 
             ttl_seconds (``int``, *optional*):
                 Self-Destruct Timer.
@@ -3721,6 +3735,7 @@ class Message(Object, Update):
             parse_mode=parse_mode,
             caption_entities=caption_entities,
             has_spoiler=has_spoiler,
+            show_caption_above_media=show_caption_above_media,
             ttl_seconds=ttl_seconds,
             duration=duration,
             width=width,
@@ -4532,6 +4547,7 @@ class Message(Object, Update):
         schedule_date: datetime = None,
         protect_content: bool = None,
         has_spoiler: bool = None,
+        show_caption_above_media: bool = None,
         business_connection_id: str = None,
         allow_paid_broadcast: bool = None,
         reply_markup: Union[
@@ -4602,6 +4618,9 @@ class Message(Object, Update):
             protect_content (``bool``, *optional*):
                 Protects the contents of the sent message from forwarding and saving.
 
+            show_caption_above_media (``bool``, *optional*):
+                Pass True, if the caption must be shown above the message media.
+
             business_connection_id (``str``, *optional*):
                 Unique identifier of the business connection on behalf of which the message will be sent.
 
@@ -4663,6 +4682,7 @@ class Message(Object, Update):
                 schedule_date=schedule_date,
                 protect_content=protect_content,
                 has_spoiler=self.has_media_spoiler if has_spoiler is None else has_spoiler,
+                show_caption_above_media=self.show_caption_above_media if show_caption_above_media is None else show_caption_above_media,
                 business_connection_id=business_connection_id,
                 allow_paid_broadcast=allow_paid_broadcast,
                 reply_markup=self.reply_markup if reply_markup is object else reply_markup


### PR DESCRIPTION
- Added the `show_caption_above_media` option to the `copy`, `reply_video`, `reply_photo`, and `reply_animation` methods.
- This enhancement ensures consistent caption placement behavior across all applicable methods.
- Updated documentation  to reflect the changes for each method.

Improves usability by providing a unified approach to caption placement across various media types.