### PR TITLE
feat(cod-gen): change raw types generation to have proper typehints

### DIFF
--- a/compiler/api/template/type.txt
+++ b/compiler/api/template/type.txt
@@ -1,23 +1,13 @@
-{notice}
-
 {warning}
+
+"""
+class {name}:
+    {docstring}
+"""
+
 
 from typing import Union
 from pyrogram import raw
 from pyrogram.raw.core import TLObject
 
 {name} = Union[{types}]
-
-
-# noinspection PyRedeclaration
-class {name}:  # type: ignore
-    """{docstring}
-    """
-
-    QUALNAME = "pyrogram.raw.base.{qualname}"
-
-    def __init__(self):
-        raise TypeError("Base types can only be used for type checking purposes: "
-                        "you tried to use a base type instance as argument, "
-                        "but you need to instantiate one of its constructors instead. "
-                        "More info: https://docs.pyrogram.org/telegram/base/{doc_name}")


### PR DESCRIPTION
## What this PR does?
- Change generation of `pyrogram/raw/base*` files to get proper typehints;

### MRE (code to check if everything works properly and shows typehints):
```python
import asyncio

from pyrogram import Client, raw


async def main() -> None:
    client = Client(
        name="account",
        api_id=8,
        api_hash="7245de8e747a0d6fbe11f7cc14fcc0bb",
    )

    await client.start()

    peer_id = 111
    peer = await client.resolve_peer(peer_id)
    result: raw.types.messages.PeerDialogs = await client.invoke(
        raw.functions.messages.GetPeerDialogs(
            peers=[peer],
        )
    )

    print(result.dialogs[0].read_outbox_max_id)
    await client.stop()


if __name__ == "__main__":
    loop = asyncio.new_event_loop()
    loop.run_until_complete(main())
```

## Before (current code) / After (PR):

### Type hints:
**Before:**
![image](https://github.com/user-attachments/assets/21e18775-c921-45f0-bf07-ec3f0ce05a30)
**After:**
![image](https://github.com/user-attachments/assets/b32f98ee-41da-4dae-82d2-83465dcaf762)

### Generated file (single type):
**Before:**
![image](https://github.com/user-attachments/assets/9cff294c-81d6-471b-83aa-a1a303890e71)
![image](https://github.com/user-attachments/assets/5a84720a-b47d-4e2e-83b6-ebac98cd931a)
**After:**
![image](https://github.com/user-attachments/assets/72a7a69a-d6c2-4af9-9eed-2d4b9fe05a43)

### Generated file (unions):
**Before:**
![image](https://github.com/user-attachments/assets/bfda7851-cfba-4086-8cae-91a976cda229)
![image](https://github.com/user-attachments/assets/0ac158f3-5ddc-4b82-8da0-54682b4d1421)
**After:**
![image](https://github.com/user-attachments/assets/5e9b700c-2e31-421e-9afb-319ab0a00a6d)




