### PR TITLE
Fix `update_folders` method

### DIFF
--- a/pyrogram/methods/chats/update_folder.py
+++ b/pyrogram/methods/chats/update_folder.py
@@ -16,11 +16,10 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Union
+from typing import List, Optional, Union
 
 import pyrogram
-from pyrogram import raw
-from pyrogram import enums
+from pyrogram import raw, utils, types, enums
 
 
 class UpdateFolder:
@@ -28,6 +27,8 @@ class UpdateFolder:
         self: "pyrogram.Client",
         folder_id: int,
         title: str,
+        parse_mode: Optional["enums.ParseMode"] = None,
+        entities: List["types.MessageEntity"] = None,
         included_chats: Union[Union[int, str], List[Union[int, str]]] = None,
         excluded_chats: Union[Union[int, str], List[Union[int, str]]] = None,
         pinned_chats: Union[Union[int, str], List[Union[int, str]]] = None,
@@ -52,6 +53,13 @@ class UpdateFolder:
 
             title (``str``):
                 Folder title.
+
+            parse_mode (:obj:`~pyrogram.enums.ParseMode`, *optional*):
+                By default, texts are parsed using both Markdown and HTML styles.
+                You can combine both syntaxes together.
+
+            entities (List of :obj:`~pyrogram.types.MessageEntity`):
+                List of special entities that appear in message text, which can be specified instead of *parse_mode*.
 
             included_chats (``int`` | ``str`` | List of ``int`` or ``str``, *optional*):
                 Users or chats that should added in the folder
@@ -86,6 +94,9 @@ class UpdateFolder:
             exclude_muted (``bool``, *optional*):
                 Pass True if folder should exclude muted users.
 
+            exclude_read (``bool``, *optional*):
+                Pass True if folder should exclude read users.
+
             exclude_archived (``bool``, *optional*):
                 Pass True if folder should exclude archived users.
 
@@ -113,12 +124,17 @@ class UpdateFolder:
         if not isinstance(pinned_chats, list):
             pinned_chats = [pinned_chats] if pinned_chats else []
 
+        title, title_entities = (await utils.parse_text_entities(self, title, parse_mode, entities)).values()
+
         r = await self.invoke(
             raw.functions.messages.UpdateDialogFilter(
                 id=folder_id,
                 filter=raw.types.DialogFilter(
                     id=folder_id,
-                    title=title,
+                    title=raw.types.TextWithEntities(
+                        text=title,
+                        entities=title_entities,
+                    ),
                     pinned_peers=[
                         await self.resolve_peer(user_id)
                         for user_id in pinned_chats

--- a/pyrogram/methods/chats/update_folder.py
+++ b/pyrogram/methods/chats/update_folder.py
@@ -52,7 +52,7 @@ class UpdateFolder:
                 Unique folder identifier.
 
             title (``str``):
-                Folder title.
+                Folder title. As of 2025-01-24, maximum length is 12 characters.
 
             parse_mode (:obj:`~pyrogram.enums.ParseMode`, *optional*):
                 By default, texts are parsed using both Markdown and HTML styles.
@@ -125,6 +125,7 @@ class UpdateFolder:
             pinned_chats = [pinned_chats] if pinned_chats else []
 
         title, title_entities = (await utils.parse_text_entities(self, title, parse_mode, entities)).values()
+        title_entities = title_entities or []  # For some reason, `title_entities` may be `None`
 
         r = await self.invoke(
             raw.functions.messages.UpdateDialogFilter(


### PR DESCRIPTION
### What this PR does?
Updates `update_folders` method to make it work (currently, it fails).

### MRE:
```python
import asyncio

from pyrogram import Client, raw


async def main() -> None:
    client = Client(
        name="account",
        api_id=8,
        api_hash="7245de8e747a0d6fbe11f7cc14fcc0bb",
    )

    await client.start()

    await client.update_folder(
        folder_id=13,
        title="NEW_NAME",
        included_chats=["me"],
    )

    await client.stop()


if __name__ == "__main__":
    loop = asyncio.new_event_loop()
    loop.run_until_complete(main())
```

### Current traceback:
```
Traceback (most recent call last):
  File "D:\Code\Personal\pyrogram\mre.py", line 35, in <module>
    loop.run_until_complete(main())
  File "C:\Program Files\Python312\Lib\asyncio\base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "D:\Code\Personal\pyrogram\mre.py", line 25, in main
    await client.update_folder(
  File "D:\Code\Personal\pyrogram\.venv\Lib\site-packages\pyrogram\methods\chats\update_folder.py", line 116, in update_folder
    r = await self.invoke(
        ^^^^^^^^^^^^^^^^^^
  File "D:\Code\Personal\pyrogram\.venv\Lib\site-packages\pyrogram\methods\advanced\invoke.py", line 94, in invoke
    r = await session.invoke(
        ^^^^^^^^^^^^^^^^^^^^^
  File "D:\Code\Personal\pyrogram\.venv\Lib\site-packages\pyrogram\session\session.py", line 406, in invoke
    return await self.send(query, timeout=timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Code\Personal\pyrogram\.venv\Lib\site-packages\pyrogram\session\session.py", line 335, in send
    message = self.msg_factory(data)
              ^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Code\Personal\pyrogram\.venv\Lib\site-packages\pyrogram\session\internals\msg_factory.py", line 37, in __call__
    len(body)
  File "D:\Code\Personal\pyrogram\.venv\Lib\site-packages\pyrogram\raw\core\tl_object.py", line 79, in __len__
    return len(self.write())
               ^^^^^^^^^^^^
  File "D:\Code\Personal\pyrogram\.venv\Lib\site-packages\pyrogram\raw\functions\messages\update_dialog_filter.py", line 82, in write
    b.write(self.filter.write())
            ^^^^^^^^^^^^^^^^^^^
  File "D:\Code\Personal\pyrogram\.venv\Lib\site-packages\pyrogram\raw\types\dialog_filter.py", line 164, in write
    b.write(self.title.write())
            ^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'write'
```

### New behavior:
```
Process finished with exit code 0
```