### PR TITLE
CRITICAL error when connecting to a proxy server

### DIFF
--- a/pyrogram/session/session.py
+++ b/pyrogram/session/session.py
@@ -145,8 +145,9 @@ class Session:
             except (AuthKeyDuplicated, Unauthorized) as e:
                 await self.stop()
                 raise e
-            except (OSError, RPCError):
+            except (OSError, RPCError) as e:
                 await self.stop()
+                raise e
             except Exception as e:
                 await self.stop()
                 raise e


### PR DESCRIPTION
Fixed a bug that caused an infinite connection to a proxy server if it was invalid.

We specified the maximum number of reconnections (I left the default 3), but it didn't work, because in the infinite loop we didn't generate an error, but kept trying to reconnect.
In the screenshot you can see for yourself that your implementation really doesn't work. This will go on forever until I stop the script.

This is a critical error because it essentially prevents the program from terminating correctly because of the infinite loop.

![image](https://github.com/user-attachments/assets/febd8ecc-89d4-40ff-b731-4618cad28bf1)
