### PR TITLE
Fix parse mode in message.copy

### DIFF
--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -4651,7 +4651,7 @@ class Message(Object, Update):
                 chat_id,
                 text=self.text,
                 entities=self.entities,
-                parse_mode=enums.ParseMode.DISABLED,
+                parse_mode=parse_mode if parse_mode is not None else enums.ParseMode.DISABLED,
                 disable_web_page_preview=not self.web_page,
                 disable_notification=disable_notification,
                 message_thread_id=message_thread_id,


### PR DESCRIPTION
Fixes hard-coded ParseMode.DISABLED in message.copy method. Specifying parse_mode there works perfectly and is useful when copying messages with modified text or caption