### PR TITLE
Fix OSError and RPCError caused by too low START_TIMEOUT

### DIFF
--- a/pyrogram/session/session.py
+++ b/pyrogram/session/session.py
@@ -46,7 +46,7 @@ class Result:
 
 
 class Session:
-    START_TIMEOUT = 2
+    START_TIMEOUT = 30
     WAIT_TIMEOUT = 15
     SLEEP_THRESHOLD = 10
     MAX_RETRIES = 10


### PR DESCRIPTION
# This issue occurs during the account login process.

In poor network conditions and with a small `START_TIMEOUT` value, `send()` will throw a `TimeoutError`. 

When `start()` calls `send()` and a timeout error occurs, it triggers an `OSError` or `RPCError`. 

This issue is **particularly** prominent in version `v2.1.38`, especially after fixing the "CRITICAL error when connecting to a proxy server"[(#132)](https://github.com/KurimuzonAkuma/pyrogram/pull/132). In previous versions, this did not cause such issues.
![log](https://github.com/user-attachments/assets/7da40764-daf1-44d7-9b41-1fb876e09954)
