### PR TITLE
Fix private channel link peer id invalid

### DIFF
--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -327,17 +327,14 @@ def get_peer_id(peer: Union[raw.base.Peer, raw.base.InputPeer, raw.base.Requeste
     raise ValueError(f"Peer type invalid: {peer}")
 
 
-def get_peer_type(peer_id: int) -> str:
-    if peer_id < 0:
-        if MIN_CHAT_ID <= peer_id:
-            return "chat"
-
-        if MIN_CHANNEL_ID <= peer_id < MAX_CHANNEL_ID:
-            return "channel"
-    elif 0 < peer_id <= MAX_USER_ID:
-        return "user"
-
-    raise ValueError(f"Peer id invalid: {peer_id}")
+def get_peer_type_new(peer_id: int) -> str:
+    peer_id_str = str(peer_id)
+    if not peer_id_str.startswith('-'):
+        return 'user'
+    elif peer_id_str.startswith('-100'):
+        return 'channel'
+    else:
+        return 'chat'
 
 
 def get_reply_to(

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -327,7 +327,7 @@ def get_peer_id(peer: Union[raw.base.Peer, raw.base.InputPeer, raw.base.Requeste
     raise ValueError(f"Peer type invalid: {peer}")
 
 
-def get_peer_type_new(peer_id: int) -> str:
+def get_peer_type(peer_id: int) -> str:
     peer_id_str = str(peer_id)
     if not peer_id_str.startswith('-'):
         return 'user'


### PR DESCRIPTION
See https://stackoverflow.com/questions/78800845/pyrogram-peer-id-invalid-error-of-private-channels-even-though-chat-id-is-correc