### PR TITLE
feat(code-generation): change `raw/base` types generation to get proper typehints

### DIFF
--- a/compiler/api/template/type.txt
+++ b/compiler/api/template/type.txt
@@ -6,18 +6,8 @@ from typing import Union
 from pyrogram import raw
 from pyrogram.raw.core import TLObject
 
+# We need to dynamically set `__doc__` due to `sphinx`
 {name} = Union[{types}]
-
-
-# noinspection PyRedeclaration
-class {name}:  # type: ignore
-    """{docstring}
-    """
-
-    QUALNAME = "pyrogram.raw.base.{qualname}"
-
-    def __init__(self):
-        raise TypeError("Base types can only be used for type checking purposes: "
-                        "you tried to use a base type instance as argument, "
-                        "but you need to instantiate one of its constructors instead. "
-                        "More info: https://docs.pyrogram.org/telegram/base/{doc_name}")
+{name}.__doc__ = """
+    {docstring}
+"""

--- a/compiler/docs/compiler.py
+++ b/compiler/docs/compiler.py
@@ -41,7 +41,7 @@ def snek(s: str):
     return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s).lower()
 
 
-def _extrat_union_name(node: ast.AST) -> str | None:
+def _extract_union_name(node: ast.AST) -> str | None:
     """Extract the name of a variable that is assigned a Union type.
 
     :param node: The AST node to extract the variable name from.
@@ -49,7 +49,7 @@ def _extrat_union_name(node: ast.AST) -> str | None:
 
     >>> import ast
     >>> parsed_ast = ast.parse("User = Union[raw.types.UserEmpty]")
-    >>> _extrat_union_name(parsed_ast.body[0])
+    >>> _extract_union_name(parsed_ast.body[0])
     'User'
     """
 
@@ -61,7 +61,7 @@ def _extrat_union_name(node: ast.AST) -> str | None:
                 return node.targets[0].id  # Variable name
 
 
-def _extrac_class_name(node: ast.AST) -> str | None:
+def _extract_class_name(node: ast.AST) -> str | None:
     """Extract the name of a class.
 
     :param node: The AST node to extract the class name from.
@@ -69,7 +69,7 @@ def _extrac_class_name(node: ast.AST) -> str | None:
 
     >>> import ast
     >>> parsed_ast = ast.parse("class User: pass")
-    >>> _extrac_class_name(parsed_ast.body[0])
+    >>> _extract_class_name(parsed_ast.body[0])
     'User'
     """
 
@@ -88,11 +88,11 @@ class NodeInfo:
 
 def parse_node_info(node: ast.AST) -> NodeInfo | None:
     """Parse an AST node and extract the class or variable name."""
-    class_name = _extrac_class_name(node)
+    class_name = _extract_class_name(node)
     if class_name:
         return NodeInfo(name=class_name, type="class")
 
-    union_name = _extrat_union_name(node)
+    union_name = _extract_union_name(node)
     if union_name:
         return NodeInfo(name=union_name, type="union")
 

--- a/compiler/docs/compiler.py
+++ b/compiler/docs/compiler.py
@@ -20,6 +20,8 @@ import ast
 import os
 import re
 import shutil
+from dataclasses import dataclass
+from typing import Literal
 
 HOME = "compiler/docs"
 DESTINATION = "docs/source/telegram"
@@ -39,6 +41,64 @@ def snek(s: str):
     return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s).lower()
 
 
+def _extrat_union_name(node: ast.AST) -> str | None:
+    """Extract the name of a variable that is assigned a Union type.
+
+    :param node: The AST node to extract the variable name from.
+    :return: The variable name if it is assigned a Union type, otherwise None.
+
+    >>> import ast
+    >>> parsed_ast = ast.parse("User = Union[raw.types.UserEmpty]")
+    >>> _extrat_union_name(parsed_ast.body[0])
+    'User'
+    """
+
+    # Check if the assigned value is a Union type
+    if isinstance(node, ast.Assign) and isinstance(node.value, ast.Subscript):
+        if isinstance(node.value.value, ast.Name) and node.value.value.id == "Union":
+            # Extract variable name
+            if isinstance(node.targets[0], ast.Name):
+                return node.targets[0].id  # Variable name
+
+
+def _extrac_class_name(node: ast.AST) -> str | None:
+    """Extract the name of a class.
+
+    :param node: The AST node to extract the class name from.
+    :return: The class name if it is a class, otherwise None.
+
+    >>> import ast
+    >>> parsed_ast = ast.parse("class User: pass")
+    >>> _extrac_class_name(parsed_ast.body[0])
+    'User'
+    """
+
+    if isinstance(node, ast.ClassDef):
+        return node.name  # Class name
+
+
+NodeType = Literal["class", "union"]
+
+
+@dataclass
+class NodeInfo:
+    name: str
+    type: NodeType
+
+
+def parse_node_info(node: ast.AST) -> NodeInfo | None:
+    """Parse an AST node and extract the class or variable name."""
+    class_name = _extrac_class_name(node)
+    if class_name:
+        return NodeInfo(name=class_name, type="class")
+
+    union_name = _extrat_union_name(node)
+    if union_name:
+        return NodeInfo(name=union_name, type="union")
+
+    return None
+
+
 def generate(source_path, base):
     all_entities = {}
 
@@ -54,13 +114,13 @@ def generate(source_path, base):
                     p = ast.parse(f.read())
 
                 for node in ast.walk(p):
-                    if isinstance(node, ast.ClassDef):
-                        name = node.name
+                    node_info = parse_node_info(node)
+                    if node_info:
                         break
                 else:
                     continue
 
-                full_path = os.path.basename(path) + "/" + snek(name).replace("_", "-") + ".rst"
+                full_path = os.path.basename(path) + "/" + snek(node_info.name).replace("_", "-") + ".rst"
 
                 if level:
                     full_path = base + "/" + full_path
@@ -69,25 +129,42 @@ def generate(source_path, base):
                 if namespace in ["base", "types", "functions"]:
                     namespace = ""
 
-                full_name = f"{(namespace + '.') if namespace else ''}{name}"
+                full_name = f"{(namespace + '.') if namespace else ''}{node_info.name}"
 
                 os.makedirs(os.path.dirname(DESTINATION + "/" + full_path), exist_ok=True)
 
                 with open(DESTINATION + "/" + full_path, "w", encoding="utf-8") as f:
+                    title_markup = "=" * len(full_name)
+                    full_class_path = "pyrogram.raw.{}".format(
+                        ".".join(full_path.split("/")[:-1]) + "." + node_info.name
+                    )
+
+                    if node_info.type == "class":
+                        directive_type = "autoclass"
+                        directive_suffix = "()"
+                        directive_option = "members"
+                    elif node_info.type == "union":
+                        directive_type = "autodata"
+                        directive_suffix = ""
+                        directive_option = "annotation"
+                    else:
+                        raise ValueError(f"Unknown node type: `{node_info.type}`")
+
                     f.write(
                         page_template.format(
                             title=full_name,
-                            title_markup="=" * len(full_name),
-                            full_class_path="pyrogram.raw.{}".format(
-                                ".".join(full_path.split("/")[:-1]) + "." + name
-                            )
+                            title_markup=title_markup,
+                            directive_type=directive_type,
+                            full_class_path=full_class_path,
+                            directive_suffix=directive_suffix,
+                            directive_option=directive_option,
                         )
                     )
 
                 if last not in all_entities:
                     all_entities[last] = []
 
-                all_entities[last].append(name)
+                all_entities[last].append(node_info.name)
 
     build(source_path)
 

--- a/compiler/docs/template/page.txt
+++ b/compiler/docs/template/page.txt
@@ -1,5 +1,5 @@
 {title}
 {title_markup}
 
-.. autoclass:: {full_class_path}()
-    :members:
+.. {directive_type}:: {full_class_path}{directive_suffix}
+    :{directive_option}:


### PR DESCRIPTION
## What this PR does?
- Change generation of `pyrogram.raw.base` files to have proper type hints in IDE and text editors.

## What this PR does in details?
- Change `pyrogram.raw.base` files template to set `__doc__` dynamically to get proper docstring for docs (`sphinx`);
- Remove redeclaration of class to have **actual** and valid union and not a dummy class just for the docs;
- Add support for both `Class` and `Union` types in `compiler/docs/compiler.py`, that's resposible for `.rst` files generation;

### Example of generated `raw/base/*.py` files:
**Before:**
<img width="520" alt="image_2025-03-10_04-07-43" src="https://github.com/user-attachments/assets/4130ecb1-16c7-45eb-b926-321b54b0930b" />

**After:**
<img width="496" alt="image_2025-03-10_04-07-43 (2)" src="https://github.com/user-attachments/assets/827cd13a-3289-49a8-9a14-37dccce051aa" />

### Example of type hints:
**MRE:**
```python
import asyncio

from pyrogram import Client, raw


async def main() -> None:
    client = Client(
        name="account",
        api_id=8,
        api_hash="7245de8e747a0d6fbe11f7cc14fcc0bb",
    )

    await client.start()

    peer_id = 111
    peer = await client.resolve_peer(peer_id)
    result: raw.types.messages.PeerDialogs = await client.invoke(
        raw.functions.messages.GetPeerDialogs(
            peers=[peer],
        )
    )

    print(result.dialogs[0].read_outbox_max_id)
    await client.stop()


if __name__ == "__main__":
    loop = asyncio.new_event_loop()
    loop.run_until_complete(main())
```

**Before:**
![image](https://github.com/user-attachments/assets/15725819-16a6-4321-b9c2-971c5f1bbd96)

**After:**
![image](https://github.com/user-attachments/assets/71b8271e-c92f-4a8a-bc87-5a6decce3dd8)

### `.rst` file generation changes:
**Before:**
```.rst
account.AuthorizationForm
=========================

.. autoclass:: pyrogram.raw.base.account.AuthorizationForm()
    :members:
```

**After:**
```.rst
account.AuthorizationForm
=========================

.. autodata:: pyrogram.raw.base.account.AuthorizationForm
   :annotation:
```


## Breaking changes:
- None, docs are still the same;