### PR TITLE
Fix Kurigram name in pypi_release.yml

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -26,7 +26,7 @@ jobs:
           python -m build
           make venv
           make api
-          twine check --strict dist/Kurigram*
+          twine check --strict dist/kurigram*
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
This pr will fix the error that is causing the ci/cd to fall (hopefully).