### PR TITLE
Make `methods.utilities.idle` use a proper logger

### DIFF
--- a/pyrogram/methods/utilities/idle.py
+++ b/pyrogram/methods/utilities/idle.py
@@ -72,7 +72,7 @@ async def idle():
     task = None
 
     def signal_handler(signum, __):
-        logging.info(f"Stop signal received ({signals[signum]}). Exiting...")
+        log.info(f"Stop signal received ({signals[signum]}). Exiting...")
         task.cancel()
 
     for s in (SIGINT, SIGTERM, SIGABRT):


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/87e6a52e-fd3c-4f84-b2dc-a5f85df96b6c)