### PR TITLE
Remove couple Pylance warnings

### DIFF
--- a/pyrogram/__init__.py
+++ b/pyrogram/__init__.py
@@ -19,6 +19,7 @@
 __version__ = "2.2.0"
 __license__ = "GNU Lesser General Public License v3.0 (LGPL-3.0)"
 __copyright__ = "Copyright (C) 2017-present Dan <https://github.com/delivrance>"
+__all__ = ('Client','handlers')
 
 from concurrent.futures.thread import ThreadPoolExecutor
 


### PR DESCRIPTION
This:
```
"Client" is not exported from module "pyrogram"
  Import from "pyrogram.client" instead
```
And this:
```
"MessageHandler" is not exported from module "pyrogram.handlers"
  Import from "pyrogram.handlers.message_handler" instead
```