### PR TITLE
Make state and street_line2 optional and robustly parse PreCheckoutQuery.info

### DIFF
--- a/pyrogram/types/bots_and_keyboards/pre_checkout_query.py
+++ b/pyrogram/types/bots_and_keyboards/pre_checkout_query.py
@@ -96,13 +96,8 @@ class PreCheckoutQuery(Object, Update):
                 name=pre_checkout_query.info.name,
                 phone_number=pre_checkout_query.info.phone,
                 email=pre_checkout_query.info.email,
-                shipping_address=types.ShippingAddress(
-                    street_line1=pre_checkout_query.info.shipping_address.street_line1,
-                    street_line2=pre_checkout_query.info.shipping_address.street_line2,
-                    city=pre_checkout_query.info.shipping_address.city,
-                    state=pre_checkout_query.info.shipping_address.state,
-                    post_code=pre_checkout_query.info.shipping_address.post_code,
-                    country_code=pre_checkout_query.info.shipping_address.country_iso2
+                shipping_address=types.ShippingAddress._parse(
+                    pre_checkout_query.info.shipping_address
                 )
             ) if pre_checkout_query.info else None,
             client=client

--- a/pyrogram/types/bots_and_keyboards/shipping_address.py
+++ b/pyrogram/types/bots_and_keyboards/shipping_address.py
@@ -16,6 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Optional
 from pyrogram import raw
 
 from ..object import Object
@@ -67,7 +68,7 @@ class ShippingAddress(Object):
     @staticmethod
     def _parse(
         shipping_address: "raw.types.PostAddress",
-    ) -> "ShippingAddress":
+    ) -> Optional["ShippingAddress"]:
         if not shipping_address:
             return None
 

--- a/pyrogram/types/messages_and_media/successful_payment.py
+++ b/pyrogram/types/messages_and_media/successful_payment.py
@@ -121,13 +121,8 @@ class SuccessfulPayment(Object):
                     name=getattr(payment_info, "name", None),
                     phone_number=getattr(payment_info, "phone", None),
                     email=getattr(payment_info, "email", None),
-                    shipping_address=types.ShippingAddress(
-                        country_code=payment.info.shipping_address.country_iso2,
-                        state=payment.info.shipping_address.state,
-                        city=payment.info.shipping_address.city,
-                        street_line1=payment.info.shipping_address.street_line1,
-                        street_line2=payment.info.shipping_address.street_line2,
-                        post_code=payment.info.shipping_address.post_code
+                    shipping_address=types.ShippingAddress._parse(
+                        payment_info.shipping_address
                     )
                 )
 


### PR DESCRIPTION
#### Changes
- In `ShippingAddress`, mark `state` and `street_line2` as optional parameters.
- In `PreCheckoutQuery._parse`, use `getattr` and `ShippingAddress._parse` to safely handle missing `info` fields without raising errors.

#### Reproduction
Given `pre_checkout_query.info`:
```json
"info": {
  "_": "types.PaymentRequestedInfo",
  "email": "test@test.test"
}
```

Previously it threw:

```bash
'NoneType' object has no attribute 'street_line1'
```