### PR TITLE
Fix `reactions` argument typing

### DIFF
--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -465,8 +465,8 @@ class Message(Object, Update):
             Additional interface options. An object for an inline keyboard, custom reply keyboard,
             instructions to remove reply keyboard or to force a reply from the user.
 
-        reactions (List of :obj:`~pyrogram.types.Reaction`):
-            List of the reactions to this message.
+        reactions (:obj:`~pyrogram.types.MessageReactions`):
+            Reactions of this message.
 
         send_paid_messages_stars (``int``, *optional*):
             The number of Telegram Stars the sender paid to send the message.
@@ -634,7 +634,7 @@ class Message(Object, Update):
                 "types.ForceReply"
             ]
         ] = None,
-        reactions: Optional[List["types.Reaction"]] = None,
+        reactions: Optional["types.MessageReactions"] = None,
         send_paid_messages_stars: Optional[int] = None,
         unread_media: Optional[bool] = None,
         silent: Optional[bool] = None,


### PR DESCRIPTION
Since parser returns a `types.MessageReactions` type, the type of `reactions` argument and its attribute in `types.Message` will be `types.MessageReactions` too; not `List[types.MessageReactions]`.

Refer:
https://github.com/KurimuzonAkuma/pyrogram/blob/ef14d4c9ce063a2db022787992f28e99bb4d093b/pyrogram/types/messages_and_media/message.py#L1359