### PR TITLE
Make authorization confirmations cleaner & Add missing string change

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -500,7 +500,7 @@ class Client(Methods):
 
                     try:
                         if not self.password:
-                            confirm = await ainput("Confirm password recovery (y/n): ", loop=self.loop)
+                            confirm = await ainput("Confirm password recovery (y/N): ", loop=self.loop)
 
                             if confirm.lower() == "y":
                                 email_pattern = await self.send_recovery_code()

--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -450,9 +450,9 @@ class Client(Methods):
                         if not value:
                             continue
 
-                        confirm = (await ainput(f'Is "{value}" correct? (y/N): ', loop=self.loop)).lower()
+                        confirm = await ainput(f'Is "{value}" correct? (y/N): ', loop=self.loop)
 
-                        if confirm == "y":
+                        if confirm.lower() == "y":
                             break
 
                     if ":" in value:
@@ -502,7 +502,7 @@ class Client(Methods):
                         if not self.password:
                             confirm = await ainput("Confirm password recovery (y/n): ", loop=self.loop)
 
-                            if confirm == "y":
+                            if confirm.lower() == "y":
                                 email_pattern = await self.send_recovery_code()
                                 print(f"The recovery code has been sent to {email_pattern}")
 
@@ -958,9 +958,9 @@ class Client(Methods):
                                 print("Invalid value")
                                 continue
 
-                            confirm = (await ainput(f'Is "{value}" correct? (y/N): ', loop=self.loop)).lower()
+                            confirm = await ainput(f'Is "{value}" correct? (y/N): ', loop=self.loop)
 
-                            if confirm == "y":
+                            if confirm.lower() == "y":
                                 await self.storage.api_id(value)
                                 break
                         except Exception as e:


### PR DESCRIPTION
You missed lowering `confirm` here:
https://github.com/KurimuzonAkuma/pyrogram/blob/14545791d05fb748e92a65f55b7fdf52952d763a/pyrogram/client.py#L503

And in general, changing an awaited method's value in-place isn't that clean, so it's better to `.lower` them in condition part (after a few line).