### PR TITLE
Update `pin_chat_message` method's return type

### DIFF
--- a/pyrogram/methods/chats/pin_chat_message.py
+++ b/pyrogram/methods/chats/pin_chat_message.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from typing import Union, Optional
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -29,7 +29,7 @@ class PinChatMessage:
         message_id: int,
         disable_notification: bool = False,
         both_sides: bool = False,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Pin a message in a group, channel or your own chat.
         You must be an administrator in the chat for this to work and must have the "can_pin_messages" admin right in
         the supergroup or "can_edit_messages" admin right in the channel.

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -6030,7 +6030,7 @@ class Message(Object, Update):
             options=option
         )
 
-    async def pin(self, disable_notification: bool = False, both_sides: bool = False) -> "types.Message":
+    async def pin(self, disable_notification: bool = False, both_sides: bool = False) -> Optional["types.Message"]:
         """Bound method *pin* of :obj:`~pyrogram.types.Message`.
 
         Use as a shortcut for:


### PR DESCRIPTION
The `messages.UpdatePinnedMessage` doesn't always return the pinned message. As it's mentioned in the `return` line:

https://github.com/KurimuzonAkuma/pyrogram/blob/97a1a69c85e080e9a49281cb5b8b5c22a772d5c1/pyrogram/methods/chats/pin_chat_message.py#L77