### PR TITLE
Add cancel subscription method for star subscriptions

### DIFF
--- a/pyrogram/methods/bots/__init__.py
+++ b/pyrogram/methods/bots/__init__.py
@@ -22,6 +22,7 @@ from .answer_pre_checkout_query import AnswerPreCheckoutQuery
 from .answer_shipping_query import AnswerShippingQuery
 from .answer_web_app_query import AnswerWebAppQuery
 from .create_invoice_link import CreateInvoiceLink
+from .cancel_stars_subscription import CancelStarSubscription
 from .delete_bot_commands import DeleteBotCommands
 from .get_bot_commands import GetBotCommands
 from .get_bot_default_privileges import GetBotDefaultPrivileges
@@ -51,6 +52,7 @@ class Bots(
     AnswerInlineQuery,
     AnswerPreCheckoutQuery,
     AnswerShippingQuery,
+    CancelStarSubscription,
     CreateInvoiceLink,
     GetInlineBotResults,
     GetOwnedBots,

--- a/pyrogram/methods/bots/cancel_stars_subscription.py
+++ b/pyrogram/methods/bots/cancel_stars_subscription.py
@@ -1,0 +1,52 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Union
+import pyrogram
+from pyrogram import raw, types
+
+class CancelStarSubscription:
+    async def cancel_stars_subscription(
+        self: "pyrogram.Client",
+        user_id: Union[int, types.InputUser],
+        charge_id: str,
+        restore: bool = False
+    ) -> bool:
+        """
+        Cancel a Telegram Stars subscription for a user.
+
+        Parameters:
+            user_id (``int`` | ``pyrogram.types.InputUser``):
+                The user whose subscription will be cancelled. Can be a user ID or an InputUser object.
+
+            charge_id (``str``):
+                The unique identifier of the payment charge to cancel.
+
+            restore (``bool``, *optional*):
+                If True, the subscription will be restored instead of cancelled. Defaults to False.
+
+        Returns:
+            ``bool``: True on success, False otherwise.
+        """
+        return await self.invoke(
+            raw.functions.payments.BotCancelStarsSubscription(
+                user_id=raw.types.InputUser(user_id) if isinstance(user_id, int) else user_id,
+                charge_id=charge_id,
+                restore=restore
+            )
+        )

--- a/pyrogram/methods/bots/cancel_stars_subscription.py
+++ b/pyrogram/methods/bots/cancel_stars_subscription.py
@@ -18,12 +18,12 @@
 
 from typing import Union
 import pyrogram
-from pyrogram import raw, types
+from pyrogram import raw
 
 class CancelStarSubscription:
-    async def cancel_stars_subscription(
+    async def cancel_star_subscription(
         self: "pyrogram.Client",
-        user_id: Union[int, types.InputUser],
+        user_id: Union[int, str],
         charge_id: str,
         restore: bool = False
     ) -> bool:
@@ -45,7 +45,7 @@ class CancelStarSubscription:
         """
         return await self.invoke(
             raw.functions.payments.BotCancelStarsSubscription(
-                user_id=raw.types.InputUser(user_id) if isinstance(user_id, int) else user_id,
+                user_id=await self.resolve_peer(user_id),
                 charge_id=charge_id,
                 restore=restore
             )

--- a/pyrogram/methods/bots/cancel_stars_subscription.py
+++ b/pyrogram/methods/bots/cancel_stars_subscription.py
@@ -31,7 +31,7 @@ class CancelStarSubscription:
         Cancel a Telegram Stars subscription for a user.
 
         Parameters:
-            user_id (``int`` | ``pyrogram.types.InputUser``):
+            user_id (``int`` | ``str``):
                 The user whose subscription will be cancelled. Can be a user ID or an InputUser object.
 
             charge_id (``str``):


### PR DESCRIPTION
This adds a method to the bot that cancels a star subscription of a user.

a direct use of this is after a user subscribes to a monthly subscription to the bot
example given is #211


---

### Method Parameters:

user_id = TG ID of the user to who will have their star subscription cancelled

charge_id = charge ID of the transaction made from the monthly subscription,
this can be stored when the create_invoice_link has been produced. 

restore = disables autorenewal of the subscriptions, and prevents the user from reactivating the subscription once the current period expires. default False