### PR TITLE
Updates for Python 3.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,18 +31,18 @@ clean-docs:
 clean: clean-venv clean-build clean-api clean-docs
 	@echo "Cleaned all directories"
 
-api:
+api: clean-api
 	cd compiler/api && ../../$(PYTHON) compiler.py
 	cd compiler/errors && ../../$(PYTHON) compiler.py
 
-docs:
+docs: clean-docs
 	cd compiler/docs && ../../$(PYTHON) compiler.py
 	$(VENV)/bin/sphinx-build -b dirhtml "docs/source" "docs/build/html" -j auto
 
 archive-docs:
 	cd docs/build/html && zip -r ../docs.zip ./
 
-build:
+build: clean-build
 	hatch build
 
 tag:

--- a/compiler/api/template/type.txt
+++ b/compiler/api/template/type.txt
@@ -2,12 +2,17 @@
 
 {warning}
 
+import sys
 from typing import Union
 from pyrogram import raw
 from pyrogram.raw.core import TLObject
 
-# We need to dynamically set `__doc__` due to `sphinx`
 {name} = Union[{types}]
-{name}.__doc__ = """
-    {docstring}
-"""
+
+# We need to dynamically set `__doc__` due to `sphinx`
+# TODO: Since 3.14, property __doc__ is read only
+# In future we need find solution to set docstring for typing types.
+if sys.version_info < (3, 14):
+    {name}.__doc__ = """
+        {docstring}
+    """

--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -38,6 +38,7 @@ from typing import AsyncGenerator, Callable, List, Optional, Type, Union
 import pyrogram
 from pyrogram import __license__, __version__, enums, raw, utils
 from pyrogram.crypto import aes
+from pyrogram.utils import get_event_loop
 from pyrogram.errors import (
     AuthBytesInvalid,
     BadRequest,
@@ -423,7 +424,7 @@ class Client(Methods):
         if isinstance(loop, asyncio.AbstractEventLoop):
             self.loop = loop
         else:
-            self.loop = asyncio.get_event_loop()
+            self.loop = get_event_loop()
 
         self.__config: "raw.types.Config" = None
 

--- a/pyrogram/connection/connection.py
+++ b/pyrogram/connection/connection.py
@@ -21,6 +21,7 @@ import logging
 from typing import Optional, Type
 
 from .transport import TCP, TCPAbridged
+from pyrogram.utils import get_event_loop
 
 log = logging.getLogger(__name__)
 
@@ -55,7 +56,7 @@ class Connection:
         if isinstance(loop, asyncio.AbstractEventLoop):
             self.loop = loop
         else:
-            self.loop = asyncio.get_event_loop()
+            self.loop = get_event_loop()
 
     async def connect(self) -> None:
         for i in range(Connection.MAX_CONNECTION_ATTEMPTS):

--- a/pyrogram/connection/transport/tcp/tcp.py
+++ b/pyrogram/connection/transport/tcp/tcp.py
@@ -22,6 +22,7 @@ import logging
 import socket
 from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, Optional, Tuple, TypedDict
+from pyrogram.utils import get_event_loop
 
 import socks
 
@@ -68,7 +69,7 @@ class TCP:
         if isinstance(loop, asyncio.AbstractEventLoop):
             self.loop = loop
         else:
-            self.loop = asyncio.get_event_loop()
+            self.loop = get_event_loop()
 
     async def _connect_via_proxy(
         self,

--- a/pyrogram/sync.py
+++ b/pyrogram/sync.py
@@ -21,6 +21,7 @@ import functools
 import inspect
 import threading
 
+from pyrogram.utils import get_event_loop
 from pyrogram import types
 from pyrogram.methods import Methods
 from pyrogram.methods.utilities import idle as idle_module, compose as compose_module
@@ -28,7 +29,7 @@ from pyrogram.methods.utilities import idle as idle_module, compose as compose_m
 
 def async_to_sync(obj, name):
     function = getattr(obj, name)
-    main_loop = asyncio.get_event_loop()
+    main_loop = get_event_loop()
 
     def async_to_sync_gen(agen, loop, is_main_thread):
         async def anext(agen):
@@ -53,7 +54,7 @@ def async_to_sync(obj, name):
         coroutine = function(*args, **kwargs)
 
         try:
-            loop = asyncio.get_event_loop()
+            loop = get_event_loop()
         except RuntimeError:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -697,3 +697,23 @@ def from_nano(nano: int) -> float:
 
 def to_nano(amount: float) -> int:
     return int(amount * 1e9)
+
+
+
+def get_event_loop() -> asyncio.AbstractEventLoop:
+    """
+    Since Python 3.14 asyncio.get_event_loop() no longer creates loops implicitly
+
+    The asyncio.get_event_loop() function now raises RuntimeError if no event loop exists.
+
+    Documentation: https://docs.python.org/3.14/library/asyncio-eventloop.html#asyncio.get_event_loop
+
+    This function is a wrapper around asyncio.get_event_loop() for backwards compatibility.
+    """
+    try:
+        return asyncio.get_event_loop()
+    except RuntimeError as ex:
+        if "There is no current event loop in thread" in str(ex):
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            return asyncio.get_event_loop()


### PR DESCRIPTION
I had error with Pyrogram+Python 3.14, because new version of Python remove depcreted login in [asyncio](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop) and in typing.

This my PR with fixes for Python 3.14. It works for me, but, I am not sure at 100% correctness in this code.

Example of error:
```python
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/app/apps/board/utils/tele.py", line 220, in get_telegram_client_user
    from pyrogram import Client
  File "/app/.venv/lib/python3.14/site-packages/pyrogram/__init__.py", line 40, in <module>
    from .sync import idle, compose
  File "/app/.venv/lib/python3.14/site-packages/pyrogram/sync.py", line 99, in <module>
    wrap(Methods)
    ~~~~^^^^^^^^^
  File "/app/.venv/lib/python3.14/site-packages/pyrogram/sync.py", line 95, in wrap
    async_to_sync(source, name)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.14/site-packages/pyrogram/sync.py", line 31, in async_to_sync
    main_loop = asyncio.get_event_loop()
  File "/usr/local/lib/python3.14/asyncio/events.py", line 715, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
                       % threading.current_thread().name)
RuntimeError: There is no current event loop in thread 'MainThread'.

```