### PR TITLE
Add single user-defined error handler support (Python 3.10+)

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -381,7 +381,7 @@ class Client(Methods):
             self.storage = SQLiteStorage(self.name, workdir=self.workdir)
 
         self.dispatcher: Dispatcher = Dispatcher(self)
-        self.error_handler: Callable[Concatenate[Exception, Client, P]] | None = None      
+        self._error_handler: Callable[Concatenate[Exception, Client, P]] | None = None      
 
         self.rnd_id = MsgId
         self._last_sync_time = time.time()

--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -33,7 +33,7 @@ from importlib import import_module
 from io import BytesIO, StringIO
 from mimetypes import MimeTypes
 from pathlib import Path
-from typing import AsyncGenerator, Callable, List, Optional, Type, Union
+from typing import AsyncGenerator, Callable, Concatenate, List, Optional, ParamSpec, Type, Union
 
 import pyrogram
 from pyrogram import __license__, __version__, enums, raw, utils
@@ -69,6 +69,9 @@ from .parser import Parser
 from .session.internals import MsgId
 
 log = logging.getLogger(__name__)
+
+
+P = ParamSpec("P")
 
 
 class Client(Methods):
@@ -378,6 +381,7 @@ class Client(Methods):
             self.storage = SQLiteStorage(self.name, workdir=self.workdir)
 
         self.dispatcher: Dispatcher = Dispatcher(self)
+        self.error_handler: Callable[Concatenate[Exception, Client, P]] | None = None      
 
         self.rnd_id = MsgId
         self._last_sync_time = time.time()
@@ -791,6 +795,19 @@ class Client(Methods):
 
         return is_min
 
+    @property
+    def error_handler(self) -> Callable[Concatenate[Exception, Client, P], None]:
+        return self._error_handler
+
+    @error_handler.setter
+    def error_handler(self, callback: Callable[Concatenate[Exception, Client, P], None]) -> None:
+        self._error_handler = callback
+
+    @error_handler.deleter
+    def error_handler(self) -> None:
+        self._error_handler = None
+        
+    
     async def handle_updates(self, updates):
         self.last_update_time = datetime.now()
 

--- a/pyrogram/dispatcher.py
+++ b/pyrogram/dispatcher.py
@@ -383,7 +383,22 @@ class Dispatcher:
                             except pyrogram.ContinuePropagation:
                                 continue
                             except Exception as e:
-                                log.exception(e)
+                                if error_handler := self.client._error_handler:
+                                    try:
+                                        if inspect.iscoroutinefunction(error_handler):
+                                            await error_handler(e, self.client, *args)
+                                        else:
+                                            await self.client.loop.run_in_executor(
+                                                self.client.executor,
+                                                error_handler_exc,
+                                                e,
+                                                self.client,
+                                                *args
+                                            )
+                                    except Exception as error_handler_exc:
+                                        log.exception(error_handler_exc)
+                                else:
+                                    log.exception(e)
 
                             break
             except pyrogram.StopPropagation:


### PR DESCRIPTION
This PR adds a Client.error_handler property that allows users to register a single callback to handle exceptions raised in update handlers

Example:
```py
from typing import Any
from pyrogram import Client

client = Client("account")

async def my_error_handler(exc: Exception, client: Client, *args: Any) -> None:
    # your error handling code here...
    pass

client.error_handler = my_error_handler

@client.on_message()
async def raise_exc(client, message) -> None:
    raise Exception("Intentionally raising this")


client.run()
```

Although this would require python 3.10 for `typing.ParamSpec` and `typing.Concatenate`.