### PR TITLE
feat(poll): add InputPollOption and support entities in options

### DIFF
--- a/pyrogram/methods/messages/send_poll.py
+++ b/pyrogram/methods/messages/send_poll.py
@@ -30,7 +30,7 @@ class SendPoll:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         question: str,
-        options: List[str],
+        options: List["types.InputPollOption"],
         is_anonymous: bool = True,
         type: "enums.PollType" = enums.PollType.REGULAR,
         allows_multiple_answers: Optional[bool] = None,
@@ -82,8 +82,8 @@ class SendPoll:
             question (``str``):
                 Poll question, 1-255 characters.
 
-            options (List of ``str``):
-                List of answer options, 2-12 strings 1-100 characters each.
+            options (List of :obj:`~pyrogram.types.InputPollOption`):
+                List of answer options to send.
 
             is_anonymous (``bool``, *optional*):
                 True, if the poll needs to be anonymous.
@@ -243,7 +243,7 @@ class SendPoll:
 
         for i, opt in enumerate(options):
             option, option_entities = (await utils.parse_text_entities(
-                self, opt, options_parse_mode, None
+                self, opt.text, options_parse_mode, opt.entities
             )).values()
 
             answers.append(

--- a/pyrogram/types/input_content/__init__.py
+++ b/pyrogram/types/input_content/__init__.py
@@ -37,6 +37,7 @@ from .input_media_photo import InputMediaPhoto
 from .input_media_video import InputMediaVideo
 from .input_message_content import InputMessageContent
 from .input_phone_contact import InputPhoneContact
+from .input_poll_option import InputPollOption
 from .input_privacy_rule import InputPrivacyRule
 from .input_privacy_rule_allow_all import InputPrivacyRuleAllowAll
 from .input_privacy_rule_allow_bots import InputPrivacyRuleAllowBots
@@ -78,6 +79,7 @@ __all__ = [
     "InputMediaVideo",
     "InputMessageContent",
     "InputPhoneContact",
+    "InputPollOption",
     "InputPrivacyRule",
     "InputPrivacyRuleAllowAll",
     "InputPrivacyRuleAllowBots",

--- a/pyrogram/types/input_content/input_poll_option.py
+++ b/pyrogram/types/input_content/input_poll_option.py
@@ -16,46 +16,33 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-import pyrogram
+from pyrogram import types
 from ..object import Object
-from ..messages_and_media.message import Str
 
 from typing import List, Optional
 
 
-
-class PollOption(Object):
-    """Contains information about one answer option in a poll.
+class InputPollOption(Object):
+    """Describes a poll option to create.
 
     Parameters:
         text (``str``):
-            Option text, 1-100 characters.
+            Option text, 1–100 characters.
 
         entities (List of :obj:`~pyrogram.types.MessageEntity`, optional):
             List of special entities that appear in the option text.
 
-            Only :obj:`~pyrogram.enums.MessageEntityType.CUSTOM_EMOJI` entities are returned by the server.
-
-        voter_count (``int``):
-            Number of users that voted for this option.
-            Equals to 0 until you vote.
-
-        data (``bytes``):
-            The data this poll option is holding.
+            The server only accepts :obj:`~pyrogram.enums.MessageEntityType.CUSTOM_EMOJI` entities.
+            Other entity types (such as bold or italic) are silently ignored by the server:
+            they do not cause an error, but they are not rendered.
     """
 
     def __init__(
         self,
-        *,
-        client: "pyrogram.Client" = None,
         text: str,
-        entities: Optional[List["pyrogram.types.MessageEntity"]] = None,
-        voter_count: int,
-        data: bytes
+        entities: Optional[List["types.MessageEntity"]] = None,
     ):
-        super().__init__(client)
+        super().__init__()
 
         self.text = text
         self.entities = entities
-        self.voter_count = voter_count
-        self.data = data

--- a/pyrogram/types/messages_and_media/poll.py
+++ b/pyrogram/types/messages_and_media/poll.py
@@ -145,19 +145,20 @@ class Poll(Object, Update):
                 if result.correct:
                     correct_option_id = i
 
+            entities = types.List(
+                filter(
+                    lambda x: x is not None,
+                    [
+                        types.MessageEntity._parse(client, entity, {})
+                        for entity in (answer.text.entities or [])
+                    ]
+                )
+            )
+
             options.append(
                 types.PollOption(
-                    text=Str(answer.text.text).init(
-                        types.List(
-                            filter(
-                                lambda x: x is not None,
-                                [
-                                    types.MessageEntity._parse(client, entity, {})
-                                    for entity in (answer.text.entities or [])
-                                ]
-                            )
-                        )
-                    ),
+                    text=Str(answer.text.text).init(entities),
+                    entities=entities or None,
                     voter_count=voter_count,
                     data=answer.option,
                     client=client


### PR DESCRIPTION
- Add `InputPollOption` for poll options with optional entities.
- Update `SendPoll` to accept `List[InputPollOption]` instead of `List[str]`.
- `PollOption` now stores returned entities.
- Only CUSTOM_EMOJI entities are supported; others are ignored.
- Docstrings updated.

Official clients now allow `poll.options` to include custom emoji, and they
fully support sending/receiving them. Pyrogram was behind, so this commit
adds that support.

⚠️⚠️⚠️: changing SendPoll.options type is not backward compatible.
`SendPoll.options` now expects `List[InputPollOption]`, so this is not backward compatible.  
Should we allow passing `List[str]` as well, and automatically wrap them into `InputPollOption` with empty `entities` to keep old code working?
