### PR TITLE
Add Error Handler

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -407,6 +407,7 @@ class Client(Methods):
         self.stop_handler = None
         self.connect_handler = None
         self.disconnect_handler = None
+        self.error_handler = None
 
         self.me: Optional[User] = None
 

--- a/pyrogram/dispatcher.py
+++ b/pyrogram/dispatcher.py
@@ -382,8 +382,24 @@ class Dispatcher:
                                 raise
                             except pyrogram.ContinuePropagation:
                                 continue
-                            except Exception as e:
-                                log.exception(e)
+                            except Exception as exc:
+                                if error_handler := self.client.error_handler:
+                                    try:
+                                        if inspect.iscoroutinefunction(error_handler):
+                                            await error_handler(exc, handler, self.client, *args)
+                                        else:
+                                            await self.client.loop.run_in_executor(
+                                                self.client.executor,
+                                                error_handler,
+                                                exc,
+                                                handler,
+                                                self.client,
+                                                *args
+                                            )
+                                    except Exception:
+                                        log.exception("Error handler raised an exception:")
+                                else:
+                                    log.exception(exc)
 
                             break
             except pyrogram.StopPropagation:

--- a/pyrogram/handlers/__init__.py
+++ b/pyrogram/handlers/__init__.py
@@ -29,6 +29,7 @@ from .start_handler import StartHandler
 from .stop_handler import StopHandler
 from .connect_handler import ConnectHandler
 from .disconnect_handler import DisconnectHandler
+from .error_handler import ErrorHandler
 from .edited_business_message_handler import EditedBusinessMessageHandler
 from .edited_message_handler import EditedMessageHandler
 from .inline_query_handler import InlineQueryHandler

--- a/pyrogram/handlers/error_handler.py
+++ b/pyrogram/handlers/error_handler.py
@@ -1,0 +1,46 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Callable
+
+from .handler import Handler
+
+
+class ErrorHandler(Handler):
+    """The Error handler class. Used to handle update errors. It is intended to be used with
+    :meth:`~pyrogram.Client.add_handler`
+
+    For a nicer way to register this handler, have a look at the
+    :meth:`~pyrogram.Client.on_error` decorator.
+
+    Parameters:
+        callback (``Callable``):
+            Pass a function that will be called when an update handler raises an exception. It takes *(exc)*, *(handler)", *(client)*
+            as positional arguments (look at the section below for a detailed description).
+
+    Other parameters:
+        exc (:obj:`Exception`):
+            The Exception object which was raised.
+        handler (:obj:`~pyrogram.handlers.handler.Handler`):
+            The handler whose callback raised this exception.
+        client (:obj:`~pyrogram.Client`):
+            The Client itself.
+    """
+
+    def __init__(self, callback: Callable):
+        super().__init__(callback)

--- a/pyrogram/handlers/error_handler.py
+++ b/pyrogram/handlers/error_handler.py
@@ -30,7 +30,7 @@ class ErrorHandler(Handler):
 
     Parameters:
         callback (``Callable``):
-            Pass a function that will be called when an update handler raises an exception. It takes *(exc)*, *(handler)", *(client)*
+            Pass a function that will be called when an update handler raises an exception. It takes *(exc)*, *(handler)*, *(client)*
             as positional arguments (look at the section below for a detailed description).
 
     Other parameters:

--- a/pyrogram/methods/decorators/__init__.py
+++ b/pyrogram/methods/decorators/__init__.py
@@ -29,6 +29,7 @@ from .on_start import OnStart
 from .on_stop import OnStop
 from .on_connect import OnConnect
 from .on_disconnect import OnDisconnect
+from .on_error import OnError
 from .on_edited_business_message import OnEditedBusinessMessage
 from .on_edited_message import OnEditedMessage
 from .on_inline_query import OnInlineQuery
@@ -59,6 +60,7 @@ class Decorators(
     OnStop,
     OnConnect,
     OnDisconnect,
+    OnError,
     OnShippingQuery,
     OnUserStatus,
     OnInlineQuery,

--- a/pyrogram/methods/decorators/on_error.py
+++ b/pyrogram/methods/decorators/on_error.py
@@ -1,0 +1,45 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Callable, Optional
+
+import pyrogram
+
+
+class OnError:
+    def on_error(self: Optional["OnError"] = None) -> Callable:
+        """Decorator for handling update errors.
+
+        This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
+        :obj:`~pyrogram.handlers.ErrorHandler`.
+
+        .. include:: /_includes/usable-by/users-bots.rst
+        """
+
+        def decorator(func: Callable) -> Callable:
+            if isinstance(self, pyrogram.Client):
+                self.add_handler(pyrogram.handlers.ErrorHandler(func))
+            else:
+                if not hasattr(func, "handlers"):
+                    func.handlers = []
+
+                func.handlers.append((pyrogram.handlers.ErrorHandler(func), 0))
+
+            return func
+
+        return decorator

--- a/pyrogram/methods/utilities/add_handler.py
+++ b/pyrogram/methods/utilities/add_handler.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import pyrogram
-from pyrogram.handlers import StartHandler, StopHandler, ConnectHandler, DisconnectHandler
+from pyrogram.handlers import StartHandler, StopHandler, ConnectHandler, DisconnectHandler, ErrorHandler
 from pyrogram.handlers.handler import Handler
 
 
@@ -67,6 +67,8 @@ class AddHandler:
             self.connect_handler = handler.callback
         elif isinstance(handler, DisconnectHandler):
             self.disconnect_handler = handler.callback
+        elif isinstance(handler, ErrorHandler):
+            self.error_handler = handler.callback
         else:
             self.dispatcher.add_handler(handler, group)
 

--- a/pyrogram/methods/utilities/remove_handler.py
+++ b/pyrogram/methods/utilities/remove_handler.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import pyrogram
-from pyrogram.handlers import StartHandler, StopHandler, ConnectHandler, DisconnectHandler
+from pyrogram.handlers import StartHandler, StopHandler, ConnectHandler, DisconnectHandler, ErrorHandler
 from pyrogram.handlers.handler import Handler
 
 
@@ -65,5 +65,7 @@ class RemoveHandler:
             self.connect_handler = None
         elif isinstance(handler, DisconnectHandler):
             self.disconnect_handler = None
+        elif isinstance(handler, ErrorHandler):
+            self.error_handler = None
         else:
             self.dispatcher.remove_handler(handler, group)


### PR DESCRIPTION
Adds a global error handler for exceptions raised in any update handler callback.

Example:
```py
from typing import Any

from pyrogram.handlers.handler import Handler
from pyrogram.types import Update
from pyrogram import Client


client = Client("account")


@client.on_error()
async def update_error_handler(exc: Exception, handler: Handler, client: Client, update: Update, *args: Any) -> None:
    # Your error handler code here...
    # Below is the example to show what you can do, but is not limited to.

    print(
        f"Caught an exception while handling {type(update).__name__} update with handler {handler.callback.__name__}:\n"
        f"Exception type: {type(exc).__name__}\n"
        f"Exception value: {str(exc)}"
    )

    # Want traceback in your hand?
    import traceback
    traceback_str: str = "".join(traceback.format_exception(
        type(exc), exc, exc.__traceback__
    ))  # or traceback.print_exception(type(exc), exc, exc.__traceback__) to directly print.
    print(traceback_str)


@client.on_message()
async def message_update_handler(client: Client, message) -> None:
    raise ValueError("This is an error message")


client.run()
```