### PR TITLE
Export base class Handler in pyrogram.handlers package for direct import

### DIFF
--- a/pyrogram/handlers/__init__.py
+++ b/pyrogram/handlers/__init__.py
@@ -16,6 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from .handler import Handler
 from .business_connection_handler import BusinessConnectionHandler
 from .business_message_handler import BusinessMessageHandler
 from .callback_query_handler import CallbackQueryHandler


### PR DESCRIPTION
This PR adds a single import to `pyrogram/handlers/__init__.py`:
```py
from .handler import Handler
```

This allows developers to import the base Handler class directly using:
```py
from pyrogram.handlers import Handler
```
instead of the longer:
```py
from pyrogram.handlers.handler import Handler
```

This allows importing class Handler together with other handlers directly from `pyrogram.handlers`, avoiding a separate import from `pyrogram.handlers.handler`.