### PR TITLE
Add Error Handler support for handling unexpected update handler exceptions

### DIFF
--- a/pyrogram/dispatcher.py
+++ b/pyrogram/dispatcher.py
@@ -20,11 +20,13 @@ import asyncio
 import inspect
 import logging
 from collections import OrderedDict
+from operator import itemgetter
 
 import pyrogram
 from pyrogram import utils
+from pyrogram.handlers.handler import Handler
 from pyrogram.handlers import (
-    CallbackQueryHandler, MessageHandler, EditedMessageHandler, DeletedMessagesHandler,
+    ErrorHandler, CallbackQueryHandler, MessageHandler, EditedMessageHandler, DeletedMessagesHandler,
     UserStatusHandler, RawUpdateHandler, InlineQueryHandler, PollHandler, PreCheckoutQueryHandler,
     ChosenInlineResultHandler, ChatMemberUpdatedHandler, ChatJoinRequestHandler, StoryHandler,
     ShippingQueryHandler, MessageReactionHandler, MessageReactionCountHandler, ChatBoostHandler,
@@ -78,6 +80,7 @@ class Dispatcher:
 
         self.updates_queue = asyncio.Queue()
         self.groups = OrderedDict()
+        self.error_handlers_groups = OrderedDict()
 
         async def message_parser(update, users, chats):
             connection_id = getattr(update, "connection_id", None)
@@ -300,11 +303,15 @@ class Dispatcher:
                 await lock.acquire()
 
             try:
-                if group not in self.groups:
-                    self.groups[group] = []
-                    self.groups = OrderedDict(sorted(self.groups.items()))
-
-                self.groups[group].append(handler)
+                if isinstance(handler, ErrorHandler):
+                    self.error_handlers_groups.setdefault(group, []).append(handler)
+                    self.error_handlers_groups = OrderedDict(sorted(self.error_handlers_groups.items(), key=itemgetter(0)))
+                else:
+                    if group not in self.groups:
+                        self.groups[group] = []
+                        self.groups = OrderedDict(sorted(self.groups.items()))
+    
+                    self.groups[group].append(handler)
             finally:
                 for lock in self.locks_list:
                     lock.release()
@@ -317,10 +324,22 @@ class Dispatcher:
                 await lock.acquire()
 
             try:
-                if group not in self.groups:
-                    raise ValueError(f"Group {group} does not exist. Handler was not removed.")
+                if isinstance(handler, ErrorHandler):
+                    if group not in self.error_handlers_groups:
+                        raise ValueError(
+                            f"Group {group} does not exist in error handlers; "
+                            "Error handler was not removed"
+                        )
 
-                self.groups[group].remove(handler)
+                    self.error_handlers_groups[group].remove(handler)
+
+                    if not self.error_handlers_groups[group]:
+                        del self.error_handlers_groups[group]
+                else:
+                    if group not in self.groups:
+                        raise ValueError(f"Group {group} does not exist. Handler was not removed.")
+    
+                    self.groups[group].remove(handler)
             finally:
                 for lock in self.locks_list:
                     lock.release()
@@ -382,11 +401,50 @@ class Dispatcher:
                                 raise
                             except pyrogram.ContinuePropagation:
                                 continue
-                            except Exception as e:
-                                log.exception(e)
+                            except Exception as exc:
+                                await self.handle_update_handler_exception(exc, handler, args)
 
                             break
             except pyrogram.StopPropagation:
                 pass
             except Exception as e:
                 log.exception(e)
+
+    async def handle_update_handler_exception(self, exc, update_handler, args) -> None:
+        handled = False
+        try:
+            for group in self.error_handlers_groups.values():
+                for handler in group:
+                    if not isinstance(exc, handler.exceptions):
+                        continue
+
+                    try:
+                        if inspect.iscoroutinefunction(handler.callback):
+                            await handler.callback(
+                                exc, update_handler, self.client, *args
+                            )
+                        else:
+                            await self.client.loop.run_in_executor(
+                                self.client.executor, handler.callback,
+                                exc, update_handler, self.client, *args
+                            )
+                    except pyrogram.StopPropagation:
+                        handled = True
+                        raise
+                    except pyrogram.ContinuePropagation:
+                        handled = True
+                        continue
+                    except Exception:
+                        log.exception("Error handler raised an exception:")
+                    else:
+                        handled = True
+
+                    break
+        except pyrogram.StopPropagation:
+            pass
+        finally:
+            if not handled:
+                log.error(
+                    f"Unexpected exception raised in {type(update_handler).__name__}:",
+                    exc_info=(type(exc), exc, exc.__traceback__)
+                )

--- a/pyrogram/handlers/__init__.py
+++ b/pyrogram/handlers/__init__.py
@@ -16,6 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from .error_handler import ErrorHandler
 from .business_connection_handler import BusinessConnectionHandler
 from .business_message_handler import BusinessMessageHandler
 from .callback_query_handler import CallbackQueryHandler

--- a/pyrogram/handlers/error_handler.py
+++ b/pyrogram/handlers/error_handler.py
@@ -1,0 +1,64 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections.abc import Sequence
+from typing import Callable
+
+from .handler import Handler
+
+
+class ErrorHandler(Handler):
+    """The Error handler class. Used to handle unexpected errors.
+
+    It is intended to be used with :meth:`~pyrogram.Client.add_handler`.
+
+    For a more convenient way to register this handler, see the
+    :meth:`~pyrogram.Client.on_error` decorator.
+
+    Parameters:
+        callback (``Callable``):
+            A function that will be called whenever an unexpected error is raised.
+            It takes the following positional arguments: *(exception, handler, client, *args)*.
+
+        exceptions (``Exception`` | ``Sequence[Exception]``, *optional*):
+            An exception type or a sequence of exception types that this handler should handle.
+            If None, the handler will catch any exception that is a subclass of ``Exception``.
+            Defaults to ``None``.
+
+    Other parameters passed to the callback:
+        exception (``Exception``):
+            The Exception instance that was raised.
+
+        handler (:obj:`~pyrogram.handlers.handler.Handler`):
+            The Handler instance from which the exception was raised.
+
+        client (:obj:`~pyrogram.Client`):
+            The Client instance, useful when calling other API methods inside the error handler.
+
+        *args (``tuple[Any, ...]``):
+            The original arguments passed to the handler.
+    """
+
+    def __init__(self, callback: Callable, exceptions: Exception | Sequence[Exception, ...] | None = None):
+        super().__init__(callback)
+
+        exceptions = exceptions or (Exception,)
+        if not isinstance(exceptions, tuple):
+            exceptions = tuple(exceptions) if isinstance(exceptions, Sequence) else (exceptions,)
+
+        self.exceptions = exceptions

--- a/pyrogram/handlers/error_handler.py
+++ b/pyrogram/handlers/error_handler.py
@@ -54,7 +54,7 @@ class ErrorHandler(Handler):
             The original arguments passed to the handler.
     """
 
-    def __init__(self, callback: Callable, exceptions: Exception | Sequence[Exception, ...] | None = None):
+    def __init__(self, callback: Callable, exceptions: Exception | Sequence[Exception] | None = None):
         super().__init__(callback)
 
         exceptions = exceptions or (Exception,)

--- a/pyrogram/methods/decorators/__init__.py
+++ b/pyrogram/methods/decorators/__init__.py
@@ -16,6 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from .on_error import OnError
 from .on_business_connection import OnBusinessConnection
 from .on_business_message import OnBusinessMessage
 from .on_callback_query import OnCallbackQuery
@@ -45,6 +46,7 @@ from .on_story import OnStory
 
 
 class Decorators(
+    OnError,
     OnBusinessConnection,
     OnBusinessMessage,
     OnMessage,

--- a/pyrogram/methods/decorators/on_error.py
+++ b/pyrogram/methods/decorators/on_error.py
@@ -1,0 +1,58 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections.abc import Sequence
+from typing import Callable, Optional
+
+import pyrogram
+
+class OnError:
+    def on_error(
+        self: Optional["OnError"] = None,
+        exceptions: Exception | tuple[Exception, ...] | None = None,
+        group: int = 0,
+    ) -> Callable:
+        """Decorator for handling unexpected errors.
+
+        This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
+        :obj:`~pyrogram.handlers.ErrorHandler`.
+
+        .. include:: /_includes/usable-by/users-bots.rst
+
+        Parameters:
+            exceptions (``Exception`` |  ``Sequence[Exception]``, *optional*):
+                An exception type or a sequence of exception types that this handler should handle.
+                If None, the handler will catch any exception that is a subclass of ``Exception``.
+                Defaults to ``None``.
+
+            group (``int``, *optional*):
+                The group identifier, defaults to 0.
+        """
+
+        def decorator(func: Callable) -> Callable:
+            if isinstance(self, pyrogram.Client):
+                self.add_handler(pyrogram.handlers.ErrorHandler(func, exceptions), group)
+            else:
+                if not hasattr(func, "handlers"):
+                    func.handlers = []
+
+                func.handlers.append((pyrogram.handlers.ErrorHandler(func, exceptions), group))
+
+            return func
+
+        return decorator


### PR DESCRIPTION
This PR introduces a new **`ErrorHandler`** class and **`@Client.on_error()`** decorator to handle exceptions raised inside update handlers.

Error handlers behave like regular update handlers — supporting **grouping**, **`StopPropagation`**, and **`ContinuePropagation`** for consistent flow control.

---

### `ErrorHandler`

**Parameters:**
- **`callback`** (`Callable`): Function called when an exception occurs.  
  Signature:
  ```python
  (exception, handler, client, *args)
  ```
  - `exception`: The raised exception instance.  
  - `handler`: The update handler where the exception originated.  
  - `client`: The active `pyrogram.Client` instance.  
  - `*args`: Original update arguments.

- **`exceptions`** (`Exception | Sequence[Exception] | None`, optional):  
  Exception types to handle. If `None`, all exceptions are caught.

- **`group`** (`int`, optional):  
  Handler priority, works the same as update handlers.

---

### `@Client.on_error()`

Decorator equivalent to adding an `ErrorHandler` manually.

```python
@Client.on_error(exceptions=(ValueError, KeyError))
async def handle_errors(exc, handler, client, *args):
    await client.send_message("me", f"Caught {type(exc).__name__}: {exc}")
```

Equivalent to:
```python
Client.add_handler(ErrorHandler(handle_errors, (ValueError, KeyError)))
```

---

### Behavior

- Exceptions in update handlers are caught and dispatched to matching error handlers.  
- `StopPropagation` stops further error handler dispatch.  
- `ContinuePropagation` skips to the next handler within the same group.  
- Unhandled exceptions are logged with traceback.  
- Exceptions raised within error handlers themselves are also logged safely.