### PR TITLE
Typing/add optional handler filters and command filter prefixes

### DIFF
--- a/pyrogram/filters.py
+++ b/pyrogram/filters.py
@@ -946,7 +946,7 @@ linked_channel = create(linked_channel_filter)
 
 
 # region command_filter
-def command(commands: Union[str, List[str]], prefixes: Union[str, List[str]] = "/", case_sensitive: bool = False):
+def command(commands: Union[str, List[str]], prefixes: Optional[Union[str, List[str]]] = "/", case_sensitive: bool = False):
     """Filter commands, i.e.: text messages starting with "/" or any other custom prefix.
 
     Parameters:

--- a/pyrogram/handlers/handler.py
+++ b/pyrogram/handlers/handler.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import inspect
-from typing import Callable
+from typing import Callable, Optional
 
 import pyrogram
 from pyrogram.filters import Filter
@@ -25,7 +25,7 @@ from pyrogram.types import Update
 
 
 class Handler:
-    def __init__(self, callback: Callable, filters: Filter = None):
+    def __init__(self, callback: Callable, filters: Optional[Filter] = None):
         self.callback = callback
         self.filters = filters
 


### PR DESCRIPTION
Changes:
class Handler.\_\_init\_\_(filters is now typed as Optional)
filters.command(prefixes is now typed as Optional)