### PR TITLE
Expose matches and content from filters.command to types.Message.command

### DIFF
--- a/pyrogram/filters.py
+++ b/pyrogram/filters.py
@@ -992,7 +992,7 @@ def command(commands: Union[str, List[str]], prefixes: Optional[Union[str, List[
         commands (``str`` | ``list``):
             The command or list of commands as string the filter should look for.
             Examples: "start", ["start", "help", "settings"]. When a message text containing
-            a command arrives, the command itself and its arguments will be stored in the *command*
+            a command arrives, the matched-prefix, matched-command and its content will be stored in the *command*
             field of the :obj:`~pyrogram.types.Message`.
 
         prefixes (``str`` | ``list``, *optional*):
@@ -1004,8 +1004,6 @@ def command(commands: Union[str, List[str]], prefixes: Optional[Union[str, List[
             Pass True if you want your command(s) to be case sensitive. Defaults to False.
             Examples: when True, command="Start" would trigger /Start but not /start.
     """
-    command_re = re.compile(r"([\"'])(.*?)(?<!\\)\1|(\S+)")
-
     async def func(flt, client: pyrogram.Client, message: Message):
         username = client.me.username or ""
         text = message.text or message.caption
@@ -1028,14 +1026,7 @@ def command(commands: Union[str, List[str]], prefixes: Optional[Union[str, List[
                 without_command = re.sub(rf"{cmd}(?:@?{username})?\s?", "", without_prefix, count=1,
                                          flags=re.IGNORECASE if not flt.case_sensitive else 0)
 
-                # match.groups are 1-indexed, group(1) is the quote, group(2) is the text
-                # between the quotes, group(3) is unquoted, whitespace-split text
-
-                # Remove the escape character from the arguments
-                message.command = [cmd] + [
-                    re.sub(r"\\([\"'])", r"\1", m.group(2) or m.group(3) or "")
-                    for m in command_re.finditer(without_command)
-                ]
+                message.command = (prefix, cmd, without_command)
 
                 return True
 

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -19,7 +19,7 @@
 import logging
 from datetime import datetime
 from functools import partial
-from typing import BinaryIO, Callable, Dict, List, Match, Optional, Union
+from typing import BinaryIO, Callable, Dict, List, Match, Optional, Tuple, Union
 
 import pyrogram
 from pyrogram import enums, raw, types, utils
@@ -343,9 +343,9 @@ class Message(Object, Update):
             A list containing all `Match Objects <https://docs.python.org/3/library/re.html#match-objects>`_ that match
             the text of this message. Only applicable when using :obj:`Filters.regex <pyrogram.Filters.regex>`.
 
-        command (List of ``str``, *optional*):
-            A list containing the command and its arguments, if any.
-            E.g.: "/start 1 2 3" would produce ["start", "1", "2", "3"].
+        command (Tuple of ``str``, *optional*):
+            A tuple containing the matched-prefix, matched-command and the content after it.
+            E.g.: "/fact Kurigram is cool!" would produce ("/", "fact", "Kurigram is cool!")
             Only applicable when using :obj:`~pyrogram.filters.command`.
 
         forum_topic_created (:obj:`~pyrogram.types.ForumTopicCreated`, *optional*):
@@ -649,7 +649,7 @@ class Message(Object, Update):
         via_bot: Optional["types.User"] = None,
         outgoing: Optional[bool] = None,
         matches: Optional[List[Match]] = None,
-        command: Optional[List[str]] = None,
+        command: Optional[Tuple[str]] = None,
         forum_topic_created: Optional["types.ForumTopicCreated"] = None,
         forum_topic_closed: Optional["types.ForumTopicClosed"] = None,
         forum_topic_reopened: Optional["types.ForumTopicReopened"] = None,


### PR DESCRIPTION
Changed filters.command() to provide matched-prefix, matched-command, content-after-it into field of types.Message.command.