### PR TITLE
Add Error Handler support for handling unexpected update handler exceptions

### DIFF
--- a/pyrogram/dispatcher.py
+++ b/pyrogram/dispatcher.py
@@ -17,10 +17,10 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
+from collections import OrderedDict
 import inspect
 import logging
-from collections import OrderedDict
-from operator import itemgetter
+from typing import Dict
 
 import pyrogram
 from pyrogram import utils
@@ -80,7 +80,6 @@ class Dispatcher:
 
         self.updates_queue = asyncio.Queue()
         self.groups = OrderedDict()
-        self.error_handlers_groups = OrderedDict()
 
         async def message_parser(update, users, chats):
             connection_id = getattr(update, "connection_id", None)
@@ -303,54 +302,32 @@ class Dispatcher:
                 await lock.acquire()
 
             try:
-                if isinstance(handler, ErrorHandler):
-                    if group not in self.error_handlers_groups:
-                        self.error_handlers_groups[group] = []
-                        self.error_handlers_groups = OrderedDict(
-                            sorted(self.error_handlers_groups.items(), key=itemgetter(0))
-                        )
+                if group not in self.groups:
+                    self.groups[group] = []
+                    self.groups = OrderedDict(sorted(self.groups.items()))
 
-                    self.error_handlers_groups[group].append(handler)
-                else:
-                    if group not in self.groups:
-                        self.groups[group] = []
-                        self.groups = OrderedDict(
-                            sorted(self.groups.items(), key=itemgetter(0))
-                        )
-
-                    self.groups[group].append(handler)
+                self.groups[group].append(handler)
             finally:
                 for lock in self.locks_list:
                     lock.release()
 
         self.client.loop.create_task(fn())
 
-    def remove_handler(self, handler, group: int):
+    def remove_handler(self, handler: Handler, group: int):
         async def fn():
             for lock in self.locks_list:
                 await lock.acquire()
 
             try:
-                if isinstance(handler, ErrorHandler):
-                    if group not in self.error_handlers_groups:
-                        raise ValueError(
-                            f"Group {group} does not exist. Error handler was not removed."
-                        )
-    
-                    self.error_handlers_groups[group].remove(handler)
-    
-                    if not self.error_handlers_groups[group]:
-                        del self.error_handlers_groups[group]
-                else:
-                    if group not in self.groups:
-                        raise ValueError(
-                            f"Group {group} does not exist. Update handler was not removed."
-                        )
-    
-                    self.groups[group].remove(handler)
-    
-                    if not self.groups[group]:
-                        del self.groups[group]
+                if group not in self.groups:
+                    raise ValueError(
+                        f"Group {group} does not exist. Handler was not removed."
+                    )
+
+                self.groups[group].remove(handler)
+
+                if not self.groups[group]:
+                    del self.groups[group]
             finally:
                 for lock in self.locks_list:
                     lock.release()
@@ -377,6 +354,9 @@ class Dispatcher:
                 async with lock:
                     for group in self.groups.values():
                         for handler in group:
+                            if isinstance(handler, ErrorHandler):
+                                continue
+
                             args = None
 
                             if isinstance(handler, handler_type):
@@ -413,7 +393,9 @@ class Dispatcher:
                             except pyrogram.ContinuePropagation:
                                 continue
                             except Exception as exc:
-                                await self.handle_update_handler_exception(exc, handler, args)
+                                await self.handle_update_handler_exception(
+                                    exc, handler, update, users, chats
+                                )
 
                             break
             except pyrogram.StopPropagation:
@@ -422,24 +404,32 @@ class Dispatcher:
                 log.exception(e)
 
     async def handle_update_handler_exception(
-        self, exc: Exception, update_handler: Handler, args: Tuple[Any, ...]
+        self,
+        exc: Exception,
+        update_handler: Handler,
+        update: pyrogram.raw.base.Update,
+        users: Dict[int, "pyrogram.raw.base.User"],
+        chats: Dict[int, "pyrogram.raw.base.Chat"]
     ) -> None:
         handled = False
         try:
-            for group in self.error_handlers_groups.values():
+            for group in self.groups.values():
                 for handler in group:
+                    if not isinstance(handler, ErrorHandler):
+                        continue
+
                     if not isinstance(exc, handler.exceptions):
                         continue
 
                     try:
                         if inspect.iscoroutinefunction(handler.callback):
                             await handler.callback(
-                                exc, update_handler, self.client, *args
+                                self.client, exc, update_handler, update, users, chats
                             )
                         else:
                             await self.client.loop.run_in_executor(
                                 self.client.executor, handler.callback,
-                                exc, update_handler, self.client, *args
+                                self.client, exc, update_handler, update, users, chats
                             )
                     except pyrogram.StopPropagation:
                         handled = True

--- a/pyrogram/dispatcher.py
+++ b/pyrogram/dispatcher.py
@@ -407,7 +407,7 @@ class Dispatcher:
         self,
         exc: Exception,
         update_handler: Handler,
-        update: pyrogram.raw.base.Update,
+        update: "pyrogram.raw.base.Update",
         users: Dict[int, "pyrogram.raw.base.User"],
         chats: Dict[int, "pyrogram.raw.base.Chat"]
     ) -> None:

--- a/pyrogram/dispatcher.py
+++ b/pyrogram/dispatcher.py
@@ -20,11 +20,13 @@ import asyncio
 import inspect
 import logging
 from collections import OrderedDict
+from operator import itemgetter
 
 import pyrogram
 from pyrogram import utils
 from pyrogram.handlers import (
-    CallbackQueryHandler, MessageHandler, EditedMessageHandler, DeletedMessagesHandler,
+    Handler,
+    ErrorHandler, CallbackQueryHandler, MessageHandler, EditedMessageHandler, DeletedMessagesHandler,
     UserStatusHandler, RawUpdateHandler, InlineQueryHandler, PollHandler, PreCheckoutQueryHandler,
     ChosenInlineResultHandler, ChatMemberUpdatedHandler, ChatJoinRequestHandler, StoryHandler,
     ShippingQueryHandler, MessageReactionHandler, MessageReactionCountHandler, ChatBoostHandler,
@@ -78,6 +80,7 @@ class Dispatcher:
 
         self.updates_queue = asyncio.Queue()
         self.groups = OrderedDict()
+        self.error_handlers_groups = OrderedDict()
 
         async def message_parser(update, users, chats):
             connection_id = getattr(update, "connection_id", None)
@@ -294,17 +297,28 @@ class Dispatcher:
 
             log.info("Stopped %s HandlerTasks", self.client.workers)
 
-    def add_handler(self, handler, group: int):
+    def add_handler(self, handler: Handler, group: int):
         async def fn():
             for lock in self.locks_list:
                 await lock.acquire()
 
             try:
-                if group not in self.groups:
-                    self.groups[group] = []
-                    self.groups = OrderedDict(sorted(self.groups.items()))
+                if isinstance(handler, ErrorHandler):
+                    if group not in self.error_handlers_groups:
+                        self.error_handlers_groups[group] = []
+                        self.error_handlers_groups = OrderedDict(
+                            sorted(self.error_handlers_groups.items(), key=itemgetter(0))
+                        )
 
-                self.groups[group].append(handler)
+                    self.error_handlers_groups[group].append(handler)
+                else:
+                    if group not in self.groups:
+                        self.groups[group] = []
+                        self.groups = OrderedDict(
+                            sorted(self.groups.items(), key=itemgetter(0))
+                        )
+
+                    self.groups[group].append(handler)
             finally:
                 for lock in self.locks_list:
                     lock.release()
@@ -317,10 +331,26 @@ class Dispatcher:
                 await lock.acquire()
 
             try:
-                if group not in self.groups:
-                    raise ValueError(f"Group {group} does not exist. Handler was not removed.")
-
-                self.groups[group].remove(handler)
+                if isinstance(handler, ErrorHandler):
+                    if group not in self.error_handlers_groups:
+                        raise ValueError(
+                            f"Group {group} does not exist. Error handler was not removed."
+                        )
+    
+                    self.error_handlers_groups[group].remove(handler)
+    
+                    if not self.error_handlers_groups[group]:
+                        del self.error_handlers_groups[group]
+                else:
+                    if group not in self.groups:
+                        raise ValueError(
+                            f"Group {group} does not exist. Update handler was not removed."
+                        )
+    
+                    self.groups[group].remove(handler)
+    
+                    if not self.groups[group]:
+                        del self.groups[group]
             finally:
                 for lock in self.locks_list:
                     lock.release()
@@ -382,11 +412,52 @@ class Dispatcher:
                                 raise
                             except pyrogram.ContinuePropagation:
                                 continue
-                            except Exception as e:
-                                log.exception(e)
+                            except Exception as exc:
+                                await self.handle_update_handler_exception(exc, handler, args)
 
                             break
             except pyrogram.StopPropagation:
                 pass
             except Exception as e:
                 log.exception(e)
+
+    async def handle_update_handler_exception(
+        self, exc: Exception, update_handler: Handler, args: Tuple[Any, ...]
+    ) -> None:
+        handled = False
+        try:
+            for group in self.error_handlers_groups.values():
+                for handler in group:
+                    if not isinstance(exc, handler.exceptions):
+                        continue
+
+                    try:
+                        if inspect.iscoroutinefunction(handler.callback):
+                            await handler.callback(
+                                exc, update_handler, self.client, *args
+                            )
+                        else:
+                            await self.client.loop.run_in_executor(
+                                self.client.executor, handler.callback,
+                                exc, update_handler, self.client, *args
+                            )
+                    except pyrogram.StopPropagation:
+                        handled = True
+                        raise
+                    except pyrogram.ContinuePropagation:
+                        handled = True
+                        continue
+                    except Exception:
+                        log.exception("Error handler raised an exception:")
+                    else:
+                        handled = True
+
+                    break
+        except pyrogram.StopPropagation:
+            pass
+        finally:
+            if not handled:
+                log.error(
+                    f"Unexpected exception raised in {type(update_handler).__name__}:",
+                    exc_info=(type(exc), exc, exc.__traceback__)
+                )

--- a/pyrogram/handlers/__init__.py
+++ b/pyrogram/handlers/__init__.py
@@ -17,6 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from .handler import Handler
+from .error_handler import ErrorHandler
 from .business_connection_handler import BusinessConnectionHandler
 from .business_message_handler import BusinessMessageHandler
 from .callback_query_handler import CallbackQueryHandler

--- a/pyrogram/handlers/error_handler.py
+++ b/pyrogram/handlers/error_handler.py
@@ -1,0 +1,70 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections.abc import Sequence
+from typing import Callable
+
+import pyrogram
+from pyrogram.types import Update
+
+from .handler import Handler
+
+
+class ErrorHandler(Handler):
+    """The Error handler class. Used to handle unexpected errors.
+
+    It is intended to be used with :meth:`~pyrogram.Client.add_handler`.
+
+    For a more convenient way to register this handler, see the
+    :meth:`~pyrogram.Client.on_error` decorator.
+
+    Parameters:
+        callback (``Callable``):
+            A function that will be called whenever an unexpected error is raised.
+            It takes the following positional arguments: *(exception, handler, client, *args)*.
+
+        exceptions (``Exception`` | ``Sequence[Exception]``, *optional*):
+            An exception type or a sequence of exception types that this handler should handle.
+            If None, the handler will catch any exception that is a subclass of ``Exception``.
+            Defaults to ``None``.
+
+    Other parameters passed to the callback:
+        exception (``Exception``):
+            The Exception instance that was raised.
+
+        handler (:obj:`~pyrogram.handlers.handler.Handler`):
+            The Handler instance from which the exception was raised.
+
+        client (:obj:`~pyrogram.Client`):
+            The Client instance, useful when calling other API methods inside the error handler.
+
+        *args (``tuple[Any, ...]``):
+            The original arguments passed to the handler.
+    """
+
+    def __init__(self, callback: Callable, exceptions: Exception | Sequence[Exception] | None = None):
+        super().__init__(callback)
+
+        exceptions = exceptions or (Exception,)
+        if not isinstance(exceptions, tuple):
+            exceptions = (exceptions,)
+
+        self.exceptions = exceptions
+
+    async def check(self, client: "pyrogram.Client", update: Update):
+        return True

--- a/pyrogram/handlers/error_handler.py
+++ b/pyrogram/handlers/error_handler.py
@@ -39,13 +39,13 @@ class ErrorHandler(Handler):
             A function that will be called whenever an unexpected error is raised.
             It takes the following positional arguments: *(exception, handler, client, *args)*.
 
-        filters (:obj:`Filter`, *optional*):
-            Pass one or more filters to allow only a subset of updates to be passed
-            in your callback function.
-
         exceptions (``Exception`` | List of ``Exception``, *optional*):
             An exception type or a sequence of exception types that this handler should handle.
             If None, the handler will catch any exception that is a subclass of ``Exception``.
+
+        filters (:obj:`Filter`, *optional*):
+            Pass one or more filters to allow only a subset of updates to be passed
+            in your callback function.
 
     Other parameters passed to the callback:
         client (:obj:`~pyrogram.Client`):
@@ -77,8 +77,8 @@ class ErrorHandler(Handler):
     def __init__(
         self,
         callback: Callable,
-        filters: Optional[Filter] = None,
         exceptions: Optional[Union[Exception, Sequence[Exception]]] = None,
+        filters: Optional[Filter] = None,
     ):
         super().__init__(callback, filters)
 

--- a/pyrogram/handlers/error_handler.py
+++ b/pyrogram/handlers/error_handler.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from collections.abc import Sequence
-from typing import Callable, Optional, Sequence, Tuple, Union
+from typing import Callable, Optional, Sequence, Union
 
 import pyrogram
 from pyrogram.filters import Filter
@@ -82,7 +82,6 @@ class ErrorHandler(Handler):
     ):
         super().__init__(callback, filters)
 
-        self.exceptions: Tuple[Exception]
         if exceptions is None:
             self.exceptions = (Exception,)
         elif isinstance(exceptions, Sequence):

--- a/pyrogram/handlers/error_handler.py
+++ b/pyrogram/handlers/error_handler.py
@@ -43,10 +43,9 @@ class ErrorHandler(Handler):
             Pass one or more filters to allow only a subset of updates to be passed
             in your callback function.
 
-        exceptions (``Exception`` | ``Sequence[Exception]``, *optional*):
+        exceptions (``Exception`` | List of ``Exception``, *optional*):
             An exception type or a sequence of exception types that this handler should handle.
             If None, the handler will catch any exception that is a subclass of ``Exception``.
-            Defaults to ``None``.
 
     Other parameters passed to the callback:
         client (:obj:`~pyrogram.Client`):
@@ -79,7 +78,7 @@ class ErrorHandler(Handler):
         self,
         callback: Callable,
         filters: Optional[Filter] = None,
-        exceptions: Optional[type[Exception] | Sequence[type[Exception]]] = None
+        exceptions: Optional[Union[Exception, Sequence[Exception]]] = None,
     ):
         super().__init__(callback, filters)
 

--- a/pyrogram/handlers/error_handler.py
+++ b/pyrogram/handlers/error_handler.py
@@ -16,7 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections.abc import Sequence
 from typing import Callable, Optional, Sequence, Union
 
 import pyrogram

--- a/pyrogram/handlers/error_handler.py
+++ b/pyrogram/handlers/error_handler.py
@@ -17,9 +17,10 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from collections.abc import Sequence
-from typing import Callable
+from typing import Callable, Optional, Sequence, Tuple, Union
 
 import pyrogram
+from pyrogram.filters import Filter
 from pyrogram.types import Update
 
 from .handler import Handler
@@ -38,33 +39,54 @@ class ErrorHandler(Handler):
             A function that will be called whenever an unexpected error is raised.
             It takes the following positional arguments: *(exception, handler, client, *args)*.
 
+        filters (:obj:`Filter`, *optional*):
+            Pass one or more filters to allow only a subset of updates to be passed
+            in your callback function.
+
         exceptions (``Exception`` | ``Sequence[Exception]``, *optional*):
             An exception type or a sequence of exception types that this handler should handle.
             If None, the handler will catch any exception that is a subclass of ``Exception``.
             Defaults to ``None``.
 
     Other parameters passed to the callback:
+        client (:obj:`~pyrogram.Client`):
+            The Client instance, useful when calling other API methods inside the error handler.
+
         exception (``Exception``):
             The Exception instance that was raised.
 
         handler (:obj:`~pyrogram.handlers.handler.Handler`):
             The Handler instance from which the exception was raised.
 
-        client (:obj:`~pyrogram.Client`):
-            The Client instance, useful when calling other API methods inside the error handler.
+        update (:obj:`~pyrogram.raw.base.Update`):
+            The received update, which can be one of the many single Updates listed in the
+            :obj:`~pyrogram.raw.base.Update` base type.
 
-        *args (``tuple[Any, ...]``):
-            The original arguments passed to the handler.
+        users (``dict``):
+            Dictionary of all :obj:`~pyrogram.types.User` mentioned in the update.
+            You can access extra info about the user (such as *first_name*, *last_name*, etc...) by using
+            the IDs you find in the *update* argument (e.g.: *users[1768841572]*).
+
+        chats (``dict``):
+            Dictionary of all :obj:`~pyrogram.types.Chat` and
+            :obj:`~pyrogram.raw.types.Channel` mentioned in the update.
+            You can access extra info about the chat (such as *title*, *participants_count*, etc...)
+            by using the IDs you find in the *update* argument (e.g.: *chats[1701277281]*).
+
     """
 
-    def __init__(self, callback: Callable, exceptions: Exception | Sequence[Exception] | None = None):
-        super().__init__(callback)
+    def __init__(
+        self,
+        callback: Callable,
+        filters: Optional[Filter] = None,
+        exceptions: Optional[type[Exception] | Sequence[type[Exception]]] = None
+    ):
+        super().__init__(callback, filters)
 
-        exceptions = exceptions or (Exception,)
-        if not isinstance(exceptions, tuple):
-            exceptions = (exceptions,)
-
-        self.exceptions = exceptions
-
-    async def check(self, client: "pyrogram.Client", update: Update):
-        return True
+        self.exceptions: Tuple[Exception]
+        if exceptions is None:
+            self.exceptions = (Exception,)
+        elif isinstance(exceptions, Sequence):
+            self.exceptions = tuple(exceptions)
+        else:
+            self.exceptions = (exceptions,)

--- a/pyrogram/methods/decorators/__init__.py
+++ b/pyrogram/methods/decorators/__init__.py
@@ -16,6 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from .on_error import OnError
 from .on_business_connection import OnBusinessConnection
 from .on_business_message import OnBusinessMessage
 from .on_callback_query import OnCallbackQuery
@@ -45,6 +46,7 @@ from .on_story import OnStory
 
 
 class Decorators(
+    OnError,
     OnBusinessConnection,
     OnBusinessMessage,
     OnMessage,

--- a/pyrogram/methods/decorators/on_error.py
+++ b/pyrogram/methods/decorators/on_error.py
@@ -16,7 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections.abc import Sequence
 from typing import Callable, Optional, Sequence, Union
 
 import pyrogram
@@ -38,13 +37,13 @@ class OnError:
         .. include:: /_includes/usable-by/users-bots.rst
 
         Parameters:
-            filters (:obj:`~pyrogram.filters`, *optional*):
-                Pass one or more filters to allow only a subset of messages to be passed
-                in your function.
-
             exceptions (``Exception`` | List of ``Exception``, *optional*):
                 An exception type or a sequence of exception types that this handler should handle.
                 If None, the handler will catch any exception that is a subclass of ``Exception``.
+
+            filters (:obj:`~pyrogram.filters`, *optional*):
+                Pass one or more filters to allow only a subset of messages to be passed
+                in your function.
 
             group (``int``, *optional*):
                 The group identifier, defaults to 0.

--- a/pyrogram/methods/decorators/on_error.py
+++ b/pyrogram/methods/decorators/on_error.py
@@ -1,0 +1,66 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections.abc import Sequence
+from typing import Callable, Optional, Sequence, Union
+
+import pyrogram
+from pyrogram.filters import Filter
+
+
+class OnError:
+    def on_error(
+        self: Optional[Union["OnError", Filter]] = None,
+        exceptions: Optional[Union[Exception, Sequence[Exception]]] = None,
+        filters: Optional[Filter] = None,
+        group: int = 0,
+    ) -> Callable:
+        """Decorator for handling unexpected errors.
+
+        This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
+        :obj:`~pyrogram.handlers.ErrorHandler`.
+
+        .. include:: /_includes/usable-by/users-bots.rst
+
+        Parameters:
+            filters (:obj:`~pyrogram.filters`, *optional*):
+                Pass one or more filters to allow only a subset of messages to be passed
+                in your function.
+
+            exceptions (``Exception`` | List of ``Exception``, *optional*):
+                An exception type or a sequence of exception types that this handler should handle.
+                If None, the handler will catch any exception that is a subclass of ``Exception``.
+
+            group (``int``, *optional*):
+                The group identifier, defaults to 0.
+        """
+
+        def decorator(func: Callable) -> Callable:
+            if isinstance(self, pyrogram.Client):
+                self.add_handler(pyrogram.handlers.ErrorHandler(func, filters, exceptions), group)
+            else:
+                if not hasattr(func, "handlers"):
+                    func.handlers = []
+
+                func.handlers.append(
+                    (pyrogram.handlers.ErrorHandler(func, filters, exceptions), group)
+                )
+
+            return func
+
+        return decorator


### PR DESCRIPTION
This PR introduces a new **`ErrorHandler`** class and **`@Client.on_error()`** decorator to handle exceptions raised inside update handlers.

Error handlers behave like regular update handlers — supporting **grouping**, **`StopPropagation`**, and **`ContinuePropagation`** for consistent flow control.

---

### `ErrorHandler`

**Parameters:**
- **`callback`** (`Callable`): Function called when an exception occurs.  
  Signature:
  ```python
  (client: Client, exception: Exception, handler: pyrogram.handlers.handler.Handler, update: pyrogram.raw.base.Update, users: dict[int, pyrogram.raw.base.User], chats: dict[int, pyrogram.raw.base.Chat])
  ```
  - `client`: The active `pyrogram.Client` instance.  
  - `exception`: The raised exception instance.
  - `handler`: The Handler instance from which the exception was raised.
  - `update`: raw base update.
  -  `users`: raw users dict.
  - `chats`: raw chats dict.

- **`exceptions`** (`Exception | Sequence[Exception] | None`, optional):  
  Exception types to handle. If `None`, all exceptions are caught.

- **`group`** (`int`, optional):  
  Handler priority, works the same as update handlers.

---

### `@Client.on_error()`

Decorator equivalent to adding an `ErrorHandler` manually.

```python
@Client.on_error(exceptions=(FloodWait, UserIsBlocked))
async def handle_errors(client, exception, handler, update, users, chats):
    await client.send_message("me", f"Caught {type(exc).__name__}: {exc}")
```

Equivalent to:
```python
Client.add_handler(ErrorHandler(handle_errors, (FloodWait, UserIsBlocked)))
```

---

### Behavior

- Exceptions in update handlers are caught and dispatched to matching error handlers.  
- `StopPropagation` stops further error handler dispatch.  
- `ContinuePropagation` skips to the next handler within the same group.  
- Unhandled exceptions are logged with traceback.  
- Exceptions raised within error handlers themselves are also logged safely.