### PR TITLE
feat: add return type hints to Update propagation methods

### DIFF
--- a/pyrogram/types/update.py
+++ b/pyrogram/types/update.py
@@ -16,12 +16,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import NoReturn
+
 import pyrogram
 
 
 class Update:
-    def stop_propagation(self):
+    def stop_propagation(self) -> NoReturn:
         raise pyrogram.StopPropagation
 
-    def continue_propagation(self):
+    def continue_propagation(self) -> NoReturn:
         raise pyrogram.ContinuePropagation


### PR DESCRIPTION
Otherwise mypy:
```bash
error: Call to untyped function "continue_propagation" in typed context  [no-untyped-call]
```