### PR TITLE
fix: time sync

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -382,10 +382,7 @@ class Client(Methods):
         self.dispatcher: Dispatcher = Dispatcher(self)
 
         self.rnd_id = MsgId
-        self._last_sync_time = time.time()
-        self._last_monotonic = time.monotonic()
-
-        self._is_server_time_synced = False
+        self._server_time_offset = 0.0
 
         self.parser: Parser = Parser(self)
 
@@ -1517,16 +1514,12 @@ class Client(Methods):
 
     @property
     def server_time(self) -> float:
-        return self._last_sync_time + (time.monotonic() - self._last_monotonic)
+        return time.time() + self._server_time_offset
 
     def _set_server_time(self, msg_id: int):
-        if self._is_server_time_synced:
-            return
-
-        self._last_sync_time = msg_id / float(2**32)
-        self._last_monotonic = time.monotonic()
-        self._is_server_time_synced = True
-        log.info(f"Time synced: {utils.timestamp_to_datetime(self._last_sync_time)}")
+        server_ts = msg_id / float(2**32)
+        self._server_time_offset = server_ts - time.time()
+        log.info(f"Time synced: offset={self._server_time_offset:.3f}s, server_time={utils.timestamp_to_datetime(server_ts)}")
 
     def guess_mime_type(self, filename: Union[str, BytesIO]) -> Optional[str]:
         if isinstance(filename, BytesIO):

--- a/pyrogram/methods/auth/disconnect.py
+++ b/pyrogram/methods/auth/disconnect.py
@@ -39,4 +39,3 @@ class Disconnect:
         await self.storage.close()
         self.session = None
         self.is_connected = False
-        self._is_server_time_synced = False

--- a/pyrogram/session/session.py
+++ b/pyrogram/session/session.py
@@ -20,7 +20,6 @@ import asyncio
 import bisect
 import logging
 import os
-import time
 from enum import Enum, auto
 from hashlib import sha1
 from io import BytesIO
@@ -260,10 +259,6 @@ class Session:
             self.recv_task = None
 
         await self._set_state(SessionState.STOPPED)
-
-        self.client._last_sync_time = time.time()
-        self.client._last_monotonic = time.monotonic()
-        self.client._is_server_time_synced = False
 
         log.info("Session stopped")
 

--- a/pyrogram/session/session.py
+++ b/pyrogram/session/session.py
@@ -20,6 +20,7 @@ import asyncio
 import bisect
 import logging
 import os
+import time
 from enum import Enum, auto
 from hashlib import sha1
 from io import BytesIO
@@ -259,6 +260,10 @@ class Session:
             self.recv_task = None
 
         await self._set_state(SessionState.STOPPED)
+
+        self.client._last_sync_time = time.time()
+        self.client._last_monotonic = time.monotonic()
+        self.client._is_server_time_synced = False
 
         log.info("Session stopped")
 


### PR DESCRIPTION
fixed error like 
```
pyrogram.session.session - Discarding packet: The msg_id belongs to over 30 seconds in the future. Most likely the client time has to be synchronized.
```
