### PR TITLE
Make WebAppData.data optional to support both WebViewDataSent actions

### DIFF
--- a/pyrogram/types/messages_and_media/web_app_data.py
+++ b/pyrogram/types/messages_and_media/web_app_data.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from typing import Optional, Union
 
 from pyrogram import raw
 from ..object import Object
@@ -46,7 +46,7 @@ class WebAppData(Object):
         self.button_text = button_text
 
     @staticmethod
-    def _parse(action: "raw.types.MessageActionWebViewDataSentMe"):
+    def _parse(action: Union["raw.types.MessageActionWebViewDataSent", "raw.types.MessageActionWebViewDataSentMe"]):
         return WebAppData(
             data=action.data,
             button_text=action.text

--- a/pyrogram/types/messages_and_media/web_app_data.py
+++ b/pyrogram/types/messages_and_media/web_app_data.py
@@ -48,6 +48,6 @@ class WebAppData(Object):
     @staticmethod
     def _parse(action: Union["raw.types.MessageActionWebViewDataSent", "raw.types.MessageActionWebViewDataSentMe"]):
         return WebAppData(
-            data=action.data,
+            data=getattr(action, "data", None),
             button_text=action.text
         )

--- a/pyrogram/types/messages_and_media/web_app_data.py
+++ b/pyrogram/types/messages_and_media/web_app_data.py
@@ -16,6 +16,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Optional
+
 from pyrogram import raw
 from ..object import Object
 
@@ -24,7 +26,7 @@ class WebAppData(Object):
     """Contains data sent from a `Web App <https://core.telegram.org/bots/webapps>`_ to the bot.
 
     Parameters:
-        data (``str``):
+        data (``str``, *optional*):
             The data.
 
         button_text (``str``):
@@ -35,7 +37,7 @@ class WebAppData(Object):
     def __init__(
         self,
         *,
-        data: str,
+        data: Optional[str],
         button_text: str,
     ):
         super().__init__()


### PR DESCRIPTION
Currently `WebAppData._parse` receives [both](https://github.com/KurimuzonAkuma/kurigram/blob/5ebde1e0bf2efaca0776349527ff1a0520e34cfc/pyrogram/types/messages_and_media/message.py#L1230-L1232)
`MessageActionWebViewDataSent` and `MessageActionWebViewDataSentMe`.

However, according to the MTProto schema, only `MessageActionWebViewDataSentMe` [contains](https://github.com/telegramdesktop/tdesktop/blob/5f1121123c6cccbb9ed9efa456c211f1c32d7299/Telegram/SourceFiles/mtproto/scheme/api.tl#L174) the `data` field, while `MessageActionWebViewDataSent` [does not](https://github.com/telegramdesktop/tdesktop/blob/5f1121123c6cccbb9ed9efa456c211f1c32d7299/Telegram/SourceFiles/mtproto/scheme/api.tl#L175).

Making `data` optional ensures both action types can be parsed correctly.