### PR TITLE
fix: chat message count in `search_messages_count` & `get_chat_history_count`

### DIFF
--- a/pyrogram/methods/messages/get_chat_history_count.py
+++ b/pyrogram/methods/messages/get_chat_history_count.py
@@ -53,20 +53,31 @@ class GetChatHistoryCount:
                 await app.get_chat_history_count(chat_id)
         """
 
-        r = await self.invoke(
-            raw.functions.messages.GetHistory(
-                peer=await self.resolve_peer(chat_id),
-                offset_id=0,
-                offset_date=0,
-                add_offset=0,
-                limit=1,
-                max_id=0,
-                min_id=0,
-                hash=0
-            )
-        )
+        peer = await self.resolve_peer(chat_id)
 
-        if isinstance(r, raw.types.messages.Messages):
-            return len(r.messages)
-        else:
-            return r.count
+        # https://t.me/tdlibchat/189410
+        ranges = await self.invoke(raw.functions.messages.GetSplitRanges())
+        total = 0
+
+        for split_range in ranges:
+            r = await self.invoke(
+                raw.functions.InvokeWithMessagesRange(
+                    range=split_range,
+                    query=raw.functions.messages.GetHistory(
+                        peer=peer,
+                        offset_id=0,
+                        offset_date=0,
+                        add_offset=0,
+                        limit=1,
+                        max_id=0,
+                        min_id=0,
+                        hash=0
+                    )
+                )
+            )
+            if isinstance(r, raw.types.messages.Messages):
+                total += len(r.messages)
+            else:
+                total += r.count
+
+        return total

--- a/pyrogram/methods/messages/search_messages_count.py
+++ b/pyrogram/methods/messages/search_messages_count.py
@@ -62,29 +62,37 @@ class SearchMessagesCount:
         Returns:
             ``int``: On success, the messages count is returned.
         """
-        r = await self.invoke(
-            raw.functions.messages.Search(
-                peer=await self.resolve_peer(chat_id),
-                q=query,
-                filter=filter.value(),
-                min_date=0,
-                max_date=0,
-                offset_id=0,
-                add_offset=0,
-                limit=1,
-                min_id=0,
-                max_id=0,
-                from_id=(
-                    await self.resolve_peer(from_user)
-                    if from_user
-                    else None
-                ),
-                top_msg_id=message_thread_id,
-                hash=0
-            )
-        )
+        peer = await self.resolve_peer(chat_id)
+        from_id = await self.resolve_peer(from_user) if from_user else None
 
-        if hasattr(r, "count"):
-            return r.count
-        else:
-            return len(r.messages)
+        # https://t.me/tdlibchat/189410
+        ranges = await self.invoke(raw.functions.messages.GetSplitRanges())
+        total = 0
+
+        for split_range in ranges:
+            r = await self.invoke(
+                raw.functions.InvokeWithMessagesRange(
+                    range=split_range,
+                    query=raw.functions.messages.Search(
+                        peer=peer,
+                        q=query,
+                        filter=filter.value(),
+                        min_date=0,
+                        max_date=0,
+                        offset_id=0,
+                        add_offset=0,
+                        limit=1,
+                        min_id=0,
+                        max_id=0,
+                        from_id=from_id,
+                        top_msg_id=message_thread_id,
+                        hash=0
+                    )
+                )
+            )
+            if hasattr(r, "count"):
+                total += r.count
+            else:
+                total += len(r.messages)
+
+        return total


### PR DESCRIPTION
TL;DR
The `search_messages_count` & `get_chat_history_count` methods return an incorrect number of messages (fewer than there actually were)

Read more: https://t.me/tdlibchat/189410