### PR TITLE
Fix get_chat_invite_link usable by

### DIFF
--- a/pyrogram/methods/invite_links/get_chat_invite_link.py
+++ b/pyrogram/methods/invite_links/get_chat_invite_link.py
@@ -30,7 +30,7 @@ class GetChatInviteLink:
     ) -> "types.ChatInviteLink":
         """Get detailed information about a chat invite link.
 
-        .. include:: /_includes/usable-by/users-bots.rst
+        .. include:: /_includes/usable-by/users.rst
 
         Parameters:
             chat_id (``int`` | ``str``):


### PR DESCRIPTION
The `get_chat_invite_link` method is only usable by `users`