### PR TITLE
make `get_chat` and `get_me` return `uses_unofficial_app` flag for a full user

### DIFF
--- a/pyrogram/types/user_and_chats/chat.py
+++ b/pyrogram/types/user_and_chats/chat.py
@@ -516,6 +516,11 @@ class Chat(Object):
             Note added to the user's contact.
             Returned only in :meth:`~pyrogram.Client.get_chat`
 
+        uses_unofficial_app (``bool``, *optional*):
+            True, if the user was marked as a user of an unofficial
+            Telegram app with security risk
+            Returned only in :meth:`~pyrogram.Client.get_chat`
+
         raw (:obj:`~pyrogram.raw.types.UserFull` | :obj:`~pyrogram.raw.types.ChatFull` | :obj:`~pyrogram.raw.types.ChannelFull`, *optional*):
             The raw chat or user object, as received from the Telegram API.
 
@@ -660,6 +665,7 @@ class Chat(Object):
         display_gifts_button: Optional[bool] = None,
         accepted_gift_types: Optional["types.AcceptedGiftTypes"] = None,
         note: Optional["types.FormattedText"] = None,
+        uses_unofficial_app: Optional[bool] = None,
         raw: Optional[Union["raw.types.UserFull", "raw.types.ChatFull", "raw.types.ChannelFull"]] = None
     ):
         super().__init__(client)
@@ -798,6 +804,7 @@ class Chat(Object):
         self.display_gifts_button = display_gifts_button
         self.accepted_gift_types = accepted_gift_types
         self.note = note
+        self.uses_unofficial_app = uses_unofficial_app
         self.raw = raw
 
     # region Deprecated
@@ -1089,6 +1096,7 @@ class Chat(Object):
         parsed_chat.display_gifts_button = user.display_gifts_button
         parsed_chat.accepted_gift_types = types.AcceptedGiftTypes._parse(user.disallowed_gifts)
         parsed_chat.note = types.FormattedText._parse(client, user.note)
+        parsed_chat.uses_unofficial_app = user.unofficial_security_risk
 
         return parsed_chat
 

--- a/pyrogram/types/user_and_chats/user.py
+++ b/pyrogram/types/user_and_chats/user.py
@@ -386,6 +386,11 @@ class User(Object, Update):
         note (:obj:`~pyrogram.types.FormattedText`, *optional*):
             Note added to the user's contact.
 
+        uses_unofficial_app (``bool``, *optional*):
+            True, if the user was marked as a user of an unofficial
+            Telegram app with security risk
+            Returned only in :meth:`~pyrogram.Client.get_me`
+
         raw (:obj:`~pyrogram.raw.base.User` | :obj:`~pyrogram.raw.base.UserStatus`, *optional*):
             The raw user or user status object, as received from the Telegram API.
 
@@ -493,6 +498,7 @@ class User(Object, Update):
         pending_rating_date: Optional[datetime] = None,
         accepted_gift_types: Optional["types.AcceptedGiftTypes"] = None,
         note: Optional["types.FormattedText"] = None,
+        uses_unofficial_app: Optional[bool] = None,
         raw: Optional[Union["raw.base.User", "raw.base.UserStatus"]] = None
     ):
         super().__init__(client)
@@ -587,6 +593,7 @@ class User(Object, Update):
         self.pending_rating_date = pending_rating_date
         self.accepted_gift_types = accepted_gift_types
         self.note = note
+        self.uses_unofficial_app = uses_unofficial_app
         self.raw = raw
 
     @property
@@ -773,6 +780,7 @@ class User(Object, Update):
         parsed_user.pending_rating_date = utils.timestamp_to_datetime(user.stars_my_pending_rating_date)
         parsed_user.accepted_gift_types = types.AcceptedGiftTypes._parse(user.disallowed_gifts)
         parsed_user.note = types.FormattedText._parse(client, user.note)
+        parsed_user.uses_unofficial_app = user.unofficial_security_risk
 
         return parsed_user
 


### PR DESCRIPTION

So that when you perform client.get_chat() you can see if this user poses a threat to your security