### PR TITLE
fix: stop_poll

### DIFF
--- a/pyrogram/methods/messages/send_poll.py
+++ b/pyrogram/methods/messages/send_poll.py
@@ -233,7 +233,7 @@ class SendPoll:
                         id=self.rnd_id(),
                         question=await question.write(self),
                         answers=[await answer.write(self) for answer in answers],
-                        hash=self.rnd_id(),
+                        hash=0,
                         closed=is_closed,
                         public_voters=not is_anonymous,
                         multiple_choice=True if correct_option_ids and len(correct_option_ids) > 1 else allows_multiple_answers,

--- a/pyrogram/methods/messages/stop_poll.py
+++ b/pyrogram/methods/messages/stop_poll.py
@@ -65,10 +65,11 @@ class StopPoll:
                 media=raw.types.InputMediaPoll(
                     poll=raw.types.Poll(
                         id=int(poll.id),
-                        closed=True,
                         question=raw.types.TextWithEntities(text="", entities=[]),
                         answers=[]
-                    )
+                        hash=0,
+                        closed=True,
+                    ),
                 ),
                 reply_markup=await reply_markup.write(self) if reply_markup else None
             )


### PR DESCRIPTION
I have noticed that in the recent update `stop_poll` **stop**ped working

```traceback
    await app.stop_poll(-482843052, 805182)
  File "/..../pyrogram/methods/messages/stop_poll.py", line 66, in stop_poll
    poll=raw.types.Poll(
         ^^^^^^^^^^^^^^^
TypeError: Poll.__init__() missing 1 required keyword-only argument: 'hash'
```

This small fix provides hash=0 and `stop_poll` stops misbehaving 👏