### PR TITLE
fix: handle optional foursquare_id or foursquare_type in send_venue

### DIFF
--- a/pyrogram/methods/messages/send_venue.py
+++ b/pyrogram/methods/messages/send_venue.py
@@ -203,8 +203,8 @@ class SendVenue:
                     title=title,
                     address=address,
                     provider="",
-                    venue_id=foursquare_id,
-                    venue_type=foursquare_type
+                    venue_id=foursquare_id or "",
+                    venue_type=foursquare_type or ""
                 ),
                 message="",
                 silent=disable_notification or None,

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -8870,7 +8870,7 @@ class Message(Object, Update):
                     longitude=self.venue.location.longitude,
                     title=self.venue.title,
                     address=self.venue.address,
-                    foursquare_id=self.venue.foursquare_id or "",
+                    foursquare_id=self.venue.foursquare_id,
                     foursquare_type=self.venue.foursquare_type,
                     disable_notification=disable_notification,
                     message_thread_id=message_thread_id,


### PR DESCRIPTION
ref: [0a8a3fb](https://github.com/KurimuzonAkuma/kurigram/commit/0a8a3fbb440674327c096357b4aada72cf3746e6)

Fixes same error in message.copy() and when msg.venue.foursquare_id is passed directly to send_venue after fetching using get_messages(). Note that just like foursquare_id, foursquare_type can too be None and cause AttributeError: 'NoneType' object has no attribute 'encode'.