### PR TITLE
Handle negative chat IDs before phone normalization

### DIFF
--- a/pyrogram/methods/advanced/resolve_peer.py
+++ b/pyrogram/methods/advanced/resolve_peer.py
@@ -104,6 +104,11 @@ class ResolvePeer:
                 except KeyError as e:
                     raise PeerIdInvalid from e
         elif isinstance(peer_id, str):
+            peer_id = peer_id.strip()
+
+            if re.fullmatch(r"-\d+", peer_id):
+                return await self.resolve_peer(int(peer_id))
+
             phone = re.sub(r'[+()\s-]', '', peer_id)
 
             if phone.isdigit():


### PR DESCRIPTION
Strip whitespace from string peer_id values and detect negative numeric chat_id/channel_id before removing symbols for phone number matching.

This prevents values like "-1001234567890" from being interpreted as phone numbers when they are passed as strings.