### PR TITLE
Add high-level music methods

### DIFF
--- a/pyrogram/methods/music/__init__.py
+++ b/pyrogram/methods/music/__init__.py
@@ -16,46 +16,20 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from .account import Account
-from .advanced import Advanced
-from .auth import Auth
-from .business import Business
-from .bots import Bots
-from .chats import Chats
-from .contacts import Contacts
-from .decorators import Decorators
-from .folders import Folders
-from .invite_links import InviteLinks
-from .messages import Messages
-from .music import Music
-from .password import Password
-from .payments import Payments
-from .phone import Phone
-from .premium import Premium
-from .users import Users
-from .stories import Stories
-from .utilities import Utilities
+from .add_music import AddMusic
+from .copy_music import CopyMusic
+from .get_chat_music import GetChatMusic
+from .get_chat_music_count import GetChatMusicCount
+from .remove_music import RemoveMusic
+from .set_music_position import SetMusicPosition
 
 
-class Methods(
-    Account,
-    Advanced,
-    Auth,
-    Business,
-    Bots,
-    Contacts,
-    Password,
-    Payments,
-    Phone,
-    Premium,
-    Chats,
-    Users,
-    Music,
-    Stories,
-    Messages,
-    Decorators,
-    Folders,
-    Utilities,
-    InviteLinks,
+class Music(
+    AddMusic,
+    CopyMusic,
+    GetChatMusic,
+    GetChatMusicCount,
+    RemoveMusic,
+    SetMusicPosition,
 ):
     pass

--- a/pyrogram/methods/music/add_music.py
+++ b/pyrogram/methods/music/add_music.py
@@ -1,0 +1,166 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from typing import BinaryIO, Callable, Optional, Union
+
+import pyrogram
+from pyrogram import StopTransmission, raw, utils
+from pyrogram.errors import FilePartMissing
+from pyrogram.file_id import FileType
+
+
+class AddMusic:
+    async def add_music(
+        self: "pyrogram.Client",
+        audio: Union[str, BinaryIO],
+        duration: Optional[int] = 0,
+        performer: Optional[str] = None,
+        title: Optional[str] = None,
+        thumb: Optional[Union[str, BinaryIO]] = None,
+        file_name: Optional[str] = None,
+        progress: Optional[Callable] = None,
+        progress_args: Optional[tuple] = (),
+    ):
+        """Add an audio file to the beginning of the current user's saved music list.
+
+        .. include:: /_includes/usable-by/users.rst
+
+        Parameters:
+            audio (``str`` | ``BinaryIO``):
+                Audio file to save.
+                Pass a file_id as string to reuse a file that already exists on Telegram servers,
+                pass a file path as string to upload a local file, or
+                pass a binary file-like object with its attribute ".name" set for in-memory uploads.
+
+            duration (``int``, *optional*):
+                Duration of the audio in seconds.
+
+            performer (``str``, *optional*):
+                Performer of the audio.
+
+            title (``str``, *optional*):
+                Title of the audio.
+
+            thumb (``str`` | ``BinaryIO``, *optional*):
+                Thumbnail of the audio.
+
+            file_name (``str``, *optional*):
+                File name of the audio.
+
+            progress (``Callable``, *optional*):
+                Pass a callback function to view the file transmission progress.
+
+            progress_args (``tuple``, *optional*):
+                Extra custom arguments for the progress callback function.
+
+        Returns:
+            ``bool`` | ``None``: On success, True is returned, otherwise, in case the upload is
+            deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
+
+        Example:
+            .. code-block:: python
+
+                await app.add_music("song.mp3", title="Title", performer="Artist")
+        """
+        file = None
+
+        try:
+            if isinstance(audio, str):
+                if os.path.isfile(audio):
+                    mime_type = self.guess_mime_type(audio) or "audio/mpeg"
+                    if mime_type == "audio/ogg":
+                        mime_type = "audio/opus"
+
+                    thumb = await self.save_file(thumb)
+                    file = await self.save_file(
+                        audio, progress=progress, progress_args=progress_args
+                    )
+
+                    uploaded_media = await self.invoke(
+                        raw.functions.messages.UploadMedia(
+                            peer=raw.types.InputPeerSelf(),
+                            media=raw.types.InputMediaUploadedDocument(
+                                mime_type=mime_type,
+                                file=file,
+                                thumb=thumb,
+                                attributes=[
+                                    raw.types.DocumentAttributeAudio(
+                                        duration=duration,
+                                        performer=performer,
+                                        title=title,
+                                    ),
+                                    raw.types.DocumentAttributeFilename(
+                                        file_name=file_name or os.path.basename(audio)
+                                    ),
+                                ],
+                            ),
+                        )
+                    )
+
+                    media = raw.types.InputDocument(
+                        id=uploaded_media.document.id,
+                        access_hash=uploaded_media.document.access_hash,
+                        file_reference=uploaded_media.document.file_reference,
+                    )
+                else:
+                    media = utils.get_input_media_from_file_id(audio, FileType.AUDIO).id
+            else:
+                mime_type = self.guess_mime_type(file_name or audio.name) or "audio/mpeg"
+                if mime_type == "audio/ogg":
+                    mime_type = "audio/opus"
+
+                thumb = await self.save_file(thumb)
+                file = await self.save_file(
+                    audio, progress=progress, progress_args=progress_args
+                )
+
+                uploaded_media = await self.invoke(
+                    raw.functions.messages.UploadMedia(
+                        peer=raw.types.InputPeerSelf(),
+                        media=raw.types.InputMediaUploadedDocument(
+                            mime_type=mime_type,
+                            file=file,
+                            thumb=thumb,
+                            attributes=[
+                                raw.types.DocumentAttributeAudio(
+                                    duration=duration,
+                                    performer=performer,
+                                    title=title,
+                                ),
+                                raw.types.DocumentAttributeFilename(
+                                    file_name=file_name or audio.name
+                                ),
+                            ],
+                        ),
+                    )
+                )
+
+                media = raw.types.InputDocument(
+                    id=uploaded_media.document.id,
+                    access_hash=uploaded_media.document.access_hash,
+                    file_reference=uploaded_media.document.file_reference,
+                )
+
+            while True:
+                try:
+                    return await self.invoke(raw.functions.account.SaveMusic(id=media))
+                except FilePartMissing as e:
+                    await self.save_file(audio, file_id=file.id, file_part=e.value)
+        except StopTransmission:
+            return None

--- a/pyrogram/methods/music/copy_music.py
+++ b/pyrogram/methods/music/copy_music.py
@@ -1,0 +1,51 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Union
+
+import pyrogram
+from pyrogram import types
+
+
+class CopyMusic:
+    async def copy_music(
+        self: "pyrogram.Client",
+        audio: Union[str, "types.Audio"],
+    ):
+        """Copy an existing Telegram audio into the current user's saved music list.
+
+        Unlike :meth:`~pyrogram.Client.copy_story`, Telegram does not expose a dedicated
+        raw ``copy`` method for saved music, so this helper reuses the source audio file_id
+        and saves it through :meth:`~pyrogram.Client.add_music`.
+
+        .. include:: /_includes/usable-by/users.rst
+
+        Parameters:
+            audio (``str`` | :obj:`~pyrogram.types.Audio`):
+                An audio ``file_id`` or a parsed :obj:`~pyrogram.types.Audio` object.
+
+        Returns:
+            ``bool``: On success, True is returned.
+
+        Example:
+            .. code-block:: python
+
+                await app.copy_music(message.audio)
+        """
+        file_id = audio.file_id if isinstance(audio, types.Audio) else audio
+        return await self.add_music(file_id)

--- a/pyrogram/methods/music/get_chat_music.py
+++ b/pyrogram/methods/music/get_chat_music.py
@@ -1,0 +1,99 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import AsyncGenerator, Optional, Union
+
+import pyrogram
+from pyrogram import raw, types
+
+
+class GetChatMusic:
+    async def get_chat_music(
+        self: "pyrogram.Client",
+        chat_id: Union[int, str],
+        limit: int = 0,
+    ) -> Optional[AsyncGenerator["types.Audio", None]]:
+        """Get a chat's saved music entries sequentially.
+
+        .. include:: /_includes/usable-by/users.rst
+
+        Parameters:
+            chat_id (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the target chat.
+                For your personal cloud (Saved Messages) you can simply use "me" or "self".
+
+            limit (``int``, *optional*):
+                Limits the number of saved music entries to be retrieved.
+                By default, no limit is applied.
+
+        Returns:
+            ``Generator``: A generator yielding :obj:`~pyrogram.types.Audio` objects.
+
+        Example:
+            .. code-block:: python
+
+                async for music in app.get_chat_music("me"):
+                    print(music.file_name)
+        """
+        peer_id = await self.resolve_peer(chat_id)
+
+        current = 0
+        total = limit or (1 << 31)
+        limit = min(100, total)
+        offset = 0
+
+        while True:
+            r = await self.invoke(
+                raw.functions.users.GetSavedMusic(
+                    id=peer_id,
+                    offset=offset,
+                    limit=limit,
+                    hash=0,
+                )
+            )
+
+            music_entries = []
+
+            for doc in r.documents:
+                attributes = {type(i): i for i in doc.attributes}
+
+                if raw.types.DocumentAttributeAudio in attributes:
+                    music_entries.append(
+                        types.Audio._parse(
+                            self,
+                            doc,
+                            attributes[raw.types.DocumentAttributeAudio],
+                            getattr(
+                                attributes.get(raw.types.DocumentAttributeFilename, None),
+                                "file_name",
+                                None,
+                            ),
+                        )
+                    )
+
+            if not music_entries:
+                return
+
+            offset += len(music_entries)
+
+            for music in music_entries:
+                yield music
+
+                current += 1
+                if current >= total:
+                    return

--- a/pyrogram/methods/music/get_chat_music_count.py
+++ b/pyrogram/methods/music/get_chat_music_count.py
@@ -1,0 +1,57 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Union
+
+import pyrogram
+from pyrogram import raw
+
+
+class GetChatMusicCount:
+    async def get_chat_music_count(
+        self: "pyrogram.Client", chat_id: Union[int, str]
+    ) -> int:
+        """Get the total count of saved music entries for a chat.
+
+        .. include:: /_includes/usable-by/users.rst
+
+        Parameters:
+            chat_id (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the target chat.
+
+        Returns:
+            ``int``: On success, the total count is returned.
+
+        Example:
+            .. code-block:: python
+
+                count = await app.get_chat_music_count("me")
+                print(count)
+        """
+        peer_id = await self.resolve_peer(chat_id)
+
+        r = await self.invoke(
+            raw.functions.users.GetSavedMusic(
+                id=peer_id,
+                offset=0,
+                limit=1,
+                hash=0,
+            )
+        )
+
+        return r.count

--- a/pyrogram/methods/music/remove_music.py
+++ b/pyrogram/methods/music/remove_music.py
@@ -1,0 +1,47 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+import pyrogram
+from pyrogram import raw, utils
+from pyrogram.file_id import FileType
+
+
+class RemoveMusic:
+    async def remove_music(self: "pyrogram.Client", file_id: str):
+        """Remove an audio file from the current user's saved music list.
+
+        .. include:: /_includes/usable-by/users.rst
+
+        Parameters:
+            file_id (``str``):
+                Identifier of the audio file to be removed.
+
+        Returns:
+            ``bool``: On success, True is returned.
+
+        Example:
+            .. code-block:: python
+
+                await app.remove_music(file_id)
+        """
+        return await self.invoke(
+            raw.functions.account.SaveMusic(
+                id=utils.get_input_media_from_file_id(file_id, FileType.AUDIO).id,
+                unsave=True,
+            )
+        )

--- a/pyrogram/methods/music/set_music_position.py
+++ b/pyrogram/methods/music/set_music_position.py
@@ -1,0 +1,59 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Optional
+
+import pyrogram
+from pyrogram import raw, utils
+from pyrogram.file_id import FileType
+
+
+class SetMusicPosition:
+    async def set_music_position(
+        self: "pyrogram.Client", file_id: str, after_file_id: Optional[str] = None
+    ):
+        """Change the position of a saved music entry.
+
+        .. include:: /_includes/usable-by/users.rst
+
+        Parameters:
+            file_id (``str``):
+                Identifier of the audio to move.
+
+            after_file_id (``str``, *optional*):
+                Identifier of the audio after which the file will be positioned.
+                Pass None to move the file to the beginning of the list.
+
+        Returns:
+            ``bool``: On success, True is returned.
+
+        Example:
+            .. code-block:: python
+
+                await app.set_music_position(file_id, after_file_id)
+        """
+        return await self.invoke(
+            raw.functions.account.SaveMusic(
+                id=utils.get_input_media_from_file_id(file_id, FileType.AUDIO).id,
+                after_id=utils.get_input_media_from_file_id(
+                    after_file_id, FileType.AUDIO
+                ).id
+                if after_file_id
+                else None,
+            )
+        )


### PR DESCRIPTION
## Summary

This PR adds a new high-level `pyrogram.methods.music` module, organized in a style similar to the existing `stories` methods group.

### Included methods
- `add_music`
- `copy_music`
- `remove_music`
- `set_music_position`
- `get_chat_music`
- `get_chat_music_count`

It also wires the new `Music` mixin into `pyrogram/methods/__init__.py` so the methods are available on the client.

## Notes

- This implementation is based on the existing `account.SaveMusic` and `users.GetSavedMusic` raw methods already used elsewhere in the project.
- `copy_music` is implemented as a high-level helper that reuses an existing audio `file_id`, because there does not appear to be a dedicated raw copy method for saved music analogous to `copy_story`.
- This contribution was developed with assistance from OpenClaw.
- There may still be edge cases or integration issues, so additional review and testing would be appreciated.

## Validation

- `python3 -m py_compile pyrogram/methods/music/*.py pyrogram/methods/__init__.py`
