### PR TITLE
feat: add waveform parameter in send_voice method

### DIFF
--- a/pyrogram/methods/messages/send_voice.py
+++ b/pyrogram/methods/messages/send_voice.py
@@ -98,6 +98,9 @@ class SendVoice:
             duration (``int``, *optional*):
                 Duration of the voice message in seconds.
 
+            waveform (``bytes``, *optional*):
+                A 5-bit byte-string waveform info.
+
             disable_notification (``bool``, *optional*):
                 Sends the message silently.
                 Users will receive a notification with no sound.

--- a/pyrogram/methods/messages/send_voice.py
+++ b/pyrogram/methods/messages/send_voice.py
@@ -38,6 +38,7 @@ class SendVoice:
         parse_mode: Optional["enums.ParseMode"] = None,
         caption_entities: List["types.MessageEntity"] = None,
         duration: int = 0,
+        waveform: Optional[bytes] = None,
         disable_notification: bool = None,
         message_thread_id: int = None,
         direct_messages_topic_id: int = None,
@@ -254,7 +255,8 @@ class SendVoice:
                         attributes=[
                             raw.types.DocumentAttributeAudio(
                                 voice=True,
-                                duration=duration
+                                duration=duration,
+                                waveform=waveform,
                             )
                         ],
                         ttl_seconds=(1 << 31) - 1 if view_once else None
@@ -276,7 +278,8 @@ class SendVoice:
                     attributes=[
                         raw.types.DocumentAttributeAudio(
                             voice=True,
-                            duration=duration
+                            duration=duration,
+                            waveform=waveform,
                         )
                     ],
                     ttl_seconds=(1 << 31) - 1 if view_once else None


### PR DESCRIPTION
usually telegram calculates these waveforms server-side.

but looks like we're missing out on making it fun and enabling the clients to pass whatever they want. With this feature it's possible to:

1. Reuse an existing voice message waveform
2. Calculate it yourself (when not fond of the default stylistics)
3. Use it as a drawing board to unleash your imagination on a very strict medium

i was able to do some drawing using this function, inspired by the telethon sources:
```python

import struct

def _encode_waveform(waveform: bytes) -> bytes:
    """
    Encode 5-bit waveform values into bytes using Telethon's algorithm.
    Each value must be in range 0-31 (5-bit).
    """
    bits_count = len(waveform) * 5
    bytes_count = (bits_count + 7) // 8
    result = bytearray(bytes_count + 1)

    for i in range(len(waveform)):
        byte_index, bit_shift = divmod(i * 5, 8)
        value = (waveform[i] & 0b00011111) << bit_shift

        or_what = struct.unpack("<H", (result[byte_index:byte_index + 2]))[0]
        or_what |= value
        result[byte_index:byte_index + 2] = struct.pack("<H", or_what)

    return bytes(result[:bytes_count])
```

<img width="773" height="2110" alt="image" src="https://github.com/user-attachments/assets/b9f27bae-9537-490a-a7b3-69df4d73b527" />
