### PR TITLE
feat: Bot API 10.2 (2/3 - Ephemeral Message)

### DIFF
--- a/pyrogram/dispatcher.py
+++ b/pyrogram/dispatcher.py
@@ -33,10 +33,14 @@ from pyrogram.handlers import (
     ChatMemberUpdatedHandler,
     ChosenInlineResultHandler,
     DeletedBusinessMessagesHandler,
+    DeletedEphemeralMessagesHandler,
     DeletedMessagesHandler,
     EditedBusinessMessageHandler,
+    EditedEphemeralMessageHandler,
     EditedMessageHandler,
     ErrorHandler,
+    EphemeralCallbackQueryHandler,
+    EphemeralMessageHandler,
     GuestMessageHandler,
     Handler,
     InlineQueryHandler,
@@ -72,14 +76,18 @@ from pyrogram.raw.types import (
     UpdateChannelParticipant,
     UpdateChatParticipant,
     UpdateDeleteChannelMessages,
+    UpdateDeleteEphemeralMessages,
     UpdateDeleteMessages,
     UpdateEditChannelMessage,
+    UpdateEditEphemeralMessage,
     UpdateEditMessage,
+    UpdateEphemeralBotCallbackQuery,
     UpdateInlineBotCallbackQuery,
     UpdateManagedBot,
     UpdateMessagePoll,
     UpdateMessagePollVote,
     UpdateNewChannelMessage,
+    UpdateNewEphemeralMessage,
     UpdateNewMessage,
     UpdateNewScheduledMessage,
     UpdateStory,
@@ -113,6 +121,10 @@ class Dispatcher:
     DELETED_BUSINESS_MESSAGES_UPDATES = (UpdateBotDeleteBusinessMessage,)
     MANAGED_BOT_UPDATES = (UpdateManagedBot,)
     GUEST_MESSAGE_UPDATES = (UpdateBotGuestChatQuery,)
+    NEW_EPHEMERAL_MESSAGE_UPDATES = (UpdateNewEphemeralMessage,)
+    EDIT_EPHEMERAL_MESSAGE_UPDATES = (UpdateEditEphemeralMessage,)
+    DELETE_EPHEMERAL_MESSAGES_UPDATES = (UpdateDeleteEphemeralMessages,)
+    EPHEMERAL_CALLBACK_QUERY_UPDATES = (UpdateEphemeralBotCallbackQuery,)
 
     def __init__(self, client: "pyrogram.Client"):
         self.client = client
@@ -289,6 +301,30 @@ class Dispatcher:
                 GuestMessageHandler
             )
 
+        async def new_ephemeral_message_parser(update, users, chats):
+            return (
+                await pyrogram.types.EphemeralMessage._parse(self.client, update.message, users, chats),
+                EphemeralMessageHandler
+            )
+
+        async def edit_ephemeral_message_parser(update, users, chats):
+            return (
+                await pyrogram.types.EphemeralMessage._parse(self.client, update.message, users, chats),
+                EditedEphemeralMessageHandler
+            )
+
+        async def delete_ephemeral_messages_parser(update, users, chats):
+            return (
+                pyrogram.types.EphemeralMessage._parse_deleted(self.client, update, users, chats),
+                DeletedEphemeralMessagesHandler
+            )
+
+        async def ephemeral_callback_query_parser(update, users, chats):
+            return (
+                await pyrogram.types.EphemeralCallbackQuery._parse(self.client, update, users, chats),
+                EphemeralCallbackQueryHandler
+            )
+
         self.update_parsers = {
             Dispatcher.NEW_MESSAGE_UPDATES: message_parser,
             Dispatcher.EDIT_MESSAGE_UPDATES: edited_message_parser,
@@ -313,6 +349,10 @@ class Dispatcher:
             Dispatcher.DELETED_BUSINESS_MESSAGES_UPDATES: deleted_business_messages_parser,
             Dispatcher.MANAGED_BOT_UPDATES: managed_bot_parser,
             Dispatcher.GUEST_MESSAGE_UPDATES: guest_message_parser,
+            Dispatcher.NEW_EPHEMERAL_MESSAGE_UPDATES: new_ephemeral_message_parser,
+            Dispatcher.EDIT_EPHEMERAL_MESSAGE_UPDATES: edit_ephemeral_message_parser,
+            Dispatcher.DELETE_EPHEMERAL_MESSAGES_UPDATES: delete_ephemeral_messages_parser,
+            Dispatcher.EPHEMERAL_CALLBACK_QUERY_UPDATES: ephemeral_callback_query_parser,
         }
 
         self.update_parsers = {key: value for key_tuple, value in self.update_parsers.items() for key in key_tuple}

--- a/pyrogram/filters.py
+++ b/pyrogram/filters.py
@@ -25,6 +25,7 @@ from pyrogram import enums
 from pyrogram.types import (
     CallbackQuery,
     ChosenInlineResult,
+    EphemeralCallbackQuery,
     InlineKeyboardMarkup,
     InlineQuery,
     Message,
@@ -1084,7 +1085,7 @@ def regex(pattern: Union[str, Pattern], flags: int = 0):
     async def func(flt, _, update: Update):
         if isinstance(update, Message):
             value = update.text or update.caption
-        elif isinstance(update, CallbackQuery):
+        elif isinstance(update, (CallbackQuery, EphemeralCallbackQuery)):
             value = update.data
         elif isinstance(update, (ChosenInlineResult, InlineQuery)):
             value = update.query

--- a/pyrogram/handlers/__init__.py
+++ b/pyrogram/handlers/__init__.py
@@ -25,10 +25,14 @@ from .chat_member_updated_handler import ChatMemberUpdatedHandler
 from .chosen_inline_result_handler import ChosenInlineResultHandler
 from .connect_handler import ConnectHandler
 from .deleted_business_messages_handler import DeletedBusinessMessagesHandler
+from .deleted_ephemeral_messages_handler import DeletedEphemeralMessagesHandler
 from .deleted_messages_handler import DeletedMessagesHandler
 from .disconnect_handler import DisconnectHandler
 from .edited_business_message_handler import EditedBusinessMessageHandler
+from .edited_ephemeral_message_handler import EditedEphemeralMessageHandler
 from .edited_message_handler import EditedMessageHandler
+from .ephemeral_callback_query_handler import EphemeralCallbackQueryHandler
+from .ephemeral_message_handler import EphemeralMessageHandler
 from .error_handler import ErrorHandler
 from .guest_message_handler import GuestMessageHandler
 from .handler import Handler

--- a/pyrogram/handlers/deleted_ephemeral_messages_handler.py
+++ b/pyrogram/handlers/deleted_ephemeral_messages_handler.py
@@ -1,0 +1,69 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import TYPE_CHECKING, Any, Callable, List
+
+from pyrogram.filters import Filter
+
+from .handler import Handler
+
+if TYPE_CHECKING:
+    import pyrogram
+    from pyrogram import types
+
+
+class DeletedEphemeralMessagesHandler(Handler):
+    """The deleted ephemeral messages handler class. Used to handle ephemeral messages that got
+    deleted from any chat. It is intended to be used with :meth:`~pyrogram.Client.add_handler`
+
+    For a nicer way to register this handler, have a look at the
+    :meth:`~pyrogram.Client.on_deleted_ephemeral_messages` decorator.
+
+    Parameters:
+        callback (``Callable``):
+            Pass a function that will be called when one or more ephemeral messages have been
+            deleted. It takes *(client, messages)* as positional arguments (look at the section
+            below for a detailed description).
+
+        filters (:obj:`Filters`):
+            Pass one or more filters to allow only a subset of messages to be passed
+            in your callback function.
+
+    Other parameters:
+        client (:obj:`~pyrogram.Client`):
+            The Client itself, useful when you want to call other API methods inside the handler.
+
+        messages (List of :obj:`~pyrogram.types.EphemeralMessage`):
+            The deleted ephemeral messages, as list.
+    """
+
+    def __init__(
+        self,
+        callback: Callable[["pyrogram.Client", List["types.EphemeralMessage"]], Any],
+        filters: Filter = None,
+    ):
+        super().__init__(callback, filters)
+
+    async def check(self, client: "pyrogram.Client", messages: List["types.EphemeralMessage"]):
+        # Every message should be checked, if at least one matches the filter True is returned
+        # otherwise, or if the list is empty, False is returned
+        for message in messages:
+            if await super().check(client, message):
+                return True
+        else:
+            return False

--- a/pyrogram/handlers/edited_ephemeral_message_handler.py
+++ b/pyrogram/handlers/edited_ephemeral_message_handler.py
@@ -1,0 +1,56 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import TYPE_CHECKING, Any, Callable
+
+from .handler import Handler
+
+if TYPE_CHECKING:
+    import pyrogram
+    from pyrogram import types
+
+
+class EditedEphemeralMessageHandler(Handler):
+    """The EditedEphemeralMessage handler class. Used to handle edited ephemeral messages.
+    It is intended to be used with :meth:`~pyrogram.Client.add_handler`
+
+    For a nicer way to register this handler, have a look at the
+    :meth:`~pyrogram.Client.on_edited_ephemeral_message` decorator.
+
+    Parameters:
+        callback (``Callable``):
+            Pass a function that will be called when an ephemeral message gets edited.
+            It takes *(client, ephemeral_message)* as positional arguments (look at the section
+            below for a detailed description).
+
+        filters (:obj:`Filters`):
+            Pass one or more filters to allow only a subset of messages to be passed
+            in your callback function.
+
+    Other parameters:
+        client (:obj:`~pyrogram.Client`):
+            The Client itself, useful when you want to call other API methods inside the handler.
+
+        edited_ephemeral_message (:obj:`~pyrogram.types.EphemeralMessage`):
+            The received edited ephemeral message.
+    """
+
+    def __init__(
+        self, callback: Callable[["pyrogram.Client", "types.EphemeralMessage"], Any], filters=None
+    ):
+        super().__init__(callback, filters)

--- a/pyrogram/handlers/ephemeral_callback_query_handler.py
+++ b/pyrogram/handlers/ephemeral_callback_query_handler.py
@@ -1,0 +1,57 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import TYPE_CHECKING, Any, Callable
+
+from .handler import Handler
+
+if TYPE_CHECKING:
+    import pyrogram
+    from pyrogram import types
+
+
+class EphemeralCallbackQueryHandler(Handler):
+    """The EphemeralCallbackQuery handler class. Used to handle callback queries coming from
+    inline buttons attached to ephemeral messages.
+    It is intended to be used with :meth:`~pyrogram.Client.add_handler`
+
+    For a nicer way to register this handler, have a look at the
+    :meth:`~pyrogram.Client.on_ephemeral_callback_query` decorator.
+
+    Parameters:
+        callback (``Callable``):
+            Pass a function that will be called when a new EphemeralCallbackQuery arrives.
+            It takes *(client, callback_query)* as positional arguments (look at the section
+            below for a detailed description).
+
+        filters (:obj:`Filters`):
+            Pass one or more filters to allow only a subset of callback queries to be passed
+            in your callback function.
+
+    Other parameters:
+        client (:obj:`~pyrogram.Client`):
+            The Client itself, useful when you want to call other API methods inside the handler.
+
+        callback_query (:obj:`~pyrogram.types.EphemeralCallbackQuery`):
+            The received callback query.
+    """
+
+    def __init__(
+        self, callback: Callable[["pyrogram.Client", "types.EphemeralCallbackQuery"], Any], filters=None
+    ):
+        super().__init__(callback, filters)

--- a/pyrogram/handlers/ephemeral_message_handler.py
+++ b/pyrogram/handlers/ephemeral_message_handler.py
@@ -1,0 +1,56 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import TYPE_CHECKING, Any, Callable
+
+from .handler import Handler
+
+if TYPE_CHECKING:
+    import pyrogram
+    from pyrogram import types
+
+
+class EphemeralMessageHandler(Handler):
+    """The EphemeralMessage handler class. Used to handle new ephemeral messages.
+    It is intended to be used with :meth:`~pyrogram.Client.add_handler`
+
+    For a nicer way to register this handler, have a look at the
+    :meth:`~pyrogram.Client.on_ephemeral_message` decorator.
+
+    Parameters:
+        callback (``Callable``):
+            Pass a function that will be called when a new ephemeral message arrives.
+            It takes *(client, ephemeral_message)* as positional arguments (look at the section
+            below for a detailed description).
+
+        filters (:obj:`Filters`):
+            Pass one or more filters to allow only a subset of messages to be passed
+            in your callback function.
+
+    Other parameters:
+        client (:obj:`~pyrogram.Client`):
+            The Client itself, useful when you want to call other API methods inside the handler.
+
+        ephemeral_message (:obj:`~pyrogram.types.EphemeralMessage`):
+            The received ephemeral message.
+    """
+
+    def __init__(
+        self, callback: Callable[["pyrogram.Client", "types.EphemeralMessage"], Any], filters=None
+    ):
+        super().__init__(callback, filters)

--- a/pyrogram/methods/bots/__init__.py
+++ b/pyrogram/methods/bots/__init__.py
@@ -42,6 +42,7 @@ from .get_owned_bots import GetOwnedBots
 from .refund_star_payment import RefundStarPayment
 from .replace_managed_bot_token import ReplaceManagedBotToken
 from .request_callback_answer import RequestCallbackAnswer
+from .request_ephemeral_callback_answer import RequestEphemeralCallbackAnswer
 from .send_chat_join_request_web_app import SendChatJoinRequestWebApp
 from .send_game import SendGame
 from .send_inline_bot_result import SendInlineBotResult
@@ -69,6 +70,7 @@ class Bots(
     GetOwnedBots,
     RefundStarPayment,
     RequestCallbackAnswer,
+    RequestEphemeralCallbackAnswer,
     SendChatJoinRequestWebApp,
     SendInlineBotResult,
     SendInvoice,

--- a/pyrogram/methods/bots/request_ephemeral_callback_answer.py
+++ b/pyrogram/methods/bots/request_ephemeral_callback_answer.py
@@ -1,0 +1,74 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Optional, Union
+
+import pyrogram
+from pyrogram import raw
+
+
+class RequestEphemeralCallbackAnswer:
+    async def request_ephemeral_callback_answer(
+        self: "pyrogram.Client",
+        chat_id: Union[int, str],
+        message_id: int,
+        callback_data: Optional[Union[str, bytes]] = None,
+        timeout: int = 10
+    ):
+        """Request a callback answer from bots, for a callback button attached to an ephemeral
+        message. This is the equivalent of clicking an inline button containing callback data.
+
+        .. include:: /_includes/usable-by/users.rst
+
+        Parameters:
+            chat_id (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the target chat.
+
+            message_id (``int``):
+                The ephemeral message id the inline keyboard is attached on.
+
+            callback_data (``str`` | ``bytes``, *optional*):
+                Callback data associated with the inline button you want to get the answer from.
+
+            timeout (``int``, *optional*):
+                Timeout in seconds.
+
+        Returns:
+            The answer containing info useful for clients to display a notification at the top of
+            the chat screen or as an alert.
+
+        Raises:
+            TimeoutError: In case the bot fails to answer within the given timeout.
+            RPCError: In case of a Telegram RPC error.
+
+        Example:
+            .. code-block:: python
+
+                await app.request_ephemeral_callback_answer(chat_id, message_id, "callback_data")
+        """
+        data = bytes(callback_data, "utf-8") if isinstance(callback_data, str) else callback_data
+
+        return await self.invoke(
+            raw.functions.ephemeral.GetCallbackAnswer(
+                peer=await self.resolve_peer(chat_id),
+                id=message_id,
+                data=data
+            ),
+            retries=1,
+            timeout=timeout
+        )

--- a/pyrogram/methods/decorators/__init__.py
+++ b/pyrogram/methods/decorators/__init__.py
@@ -25,10 +25,14 @@ from .on_chat_member_updated import OnChatMemberUpdated
 from .on_chosen_inline_result import OnChosenInlineResult
 from .on_connect import OnConnect
 from .on_deleted_business_messages import OnDeletedBusinessMessages
+from .on_deleted_ephemeral_messages import OnDeletedEphemeralMessages
 from .on_deleted_messages import OnDeletedMessages
 from .on_disconnect import OnDisconnect
 from .on_edited_business_message import OnEditedBusinessMessage
+from .on_edited_ephemeral_message import OnEditedEphemeralMessage
 from .on_edited_message import OnEditedMessage
+from .on_ephemeral_callback_query import OnEphemeralCallbackQuery
+from .on_ephemeral_message import OnEphemeralMessage
 from .on_error import OnError
 from .on_guest_message import OnGuestMessage
 from .on_inline_query import OnInlineQuery
@@ -57,10 +61,14 @@ class Decorators(
     OnChosenInlineResult,
     OnConnect,
     OnDeletedBusinessMessages,
+    OnDeletedEphemeralMessages,
     OnDeletedMessages,
     OnDisconnect,
     OnEditedBusinessMessage,
+    OnEditedEphemeralMessage,
     OnEditedMessage,
+    OnEphemeralCallbackQuery,
+    OnEphemeralMessage,
     OnError,
     OnGuestMessage,
     OnInlineQuery,

--- a/pyrogram/methods/decorators/on_deleted_ephemeral_messages.py
+++ b/pyrogram/methods/decorators/on_deleted_ephemeral_messages.py
@@ -1,0 +1,63 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Callable, Optional, Union
+
+import pyrogram
+from pyrogram.filters import Filter
+
+
+class OnDeletedEphemeralMessages:
+    def on_deleted_ephemeral_messages(
+        self: Union["OnDeletedEphemeralMessages", Filter, None] = None,
+        filters: Optional[Filter] = None,
+        group: int = 0,
+    ) -> Callable:
+        """Decorator for handling deleted ephemeral messages.
+
+        This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
+        :obj:`~pyrogram.handlers.DeletedEphemeralMessagesHandler`.
+
+        .. include:: /_includes/usable-by/bots.rst
+
+        Parameters:
+            filters (:obj:`~pyrogram.filters`, *optional*):
+                Pass one or more filters to allow only a subset of messages to be passed
+                in your function.
+
+            group (``int``, *optional*):
+                The group identifier, defaults to 0.
+        """
+
+        def decorator(func: Callable) -> Callable:
+            if isinstance(self, pyrogram.Client):
+                self.add_handler(pyrogram.handlers.DeletedEphemeralMessagesHandler(func, filters), group)
+            elif isinstance(self, Filter) or self is None:
+                if not hasattr(func, "handlers"):
+                    func.handlers = []
+
+                func.handlers.append(
+                    (
+                        pyrogram.handlers.DeletedEphemeralMessagesHandler(func, self),
+                        group if filters is None else filters
+                    )
+                )
+
+            return func
+
+        return decorator

--- a/pyrogram/methods/decorators/on_edited_ephemeral_message.py
+++ b/pyrogram/methods/decorators/on_edited_ephemeral_message.py
@@ -1,0 +1,63 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Callable, Optional, Union
+
+import pyrogram
+from pyrogram.filters import Filter
+
+
+class OnEditedEphemeralMessage:
+    def on_edited_ephemeral_message(
+        self: Union["OnEditedEphemeralMessage", Filter, None] = None,
+        filters: Optional[Filter] = None,
+        group: int = 0,
+    ) -> Callable:
+        """Decorator for handling edited ephemeral messages.
+
+        This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
+        :obj:`~pyrogram.handlers.EditedEphemeralMessageHandler`.
+
+        .. include:: /_includes/usable-by/bots.rst
+
+        Parameters:
+            filters (:obj:`~pyrogram.filters`, *optional*):
+                Pass one or more filters to allow only a subset of messages to be passed
+                in your function.
+
+            group (``int``, *optional*):
+                The group identifier, defaults to 0.
+        """
+
+        def decorator(func: Callable) -> Callable:
+            if isinstance(self, pyrogram.Client):
+                self.add_handler(pyrogram.handlers.EditedEphemeralMessageHandler(func, filters), group)
+            elif isinstance(self, Filter) or self is None:
+                if not hasattr(func, "handlers"):
+                    func.handlers = []
+
+                func.handlers.append(
+                    (
+                        pyrogram.handlers.EditedEphemeralMessageHandler(func, self),
+                        group if filters is None else filters
+                    )
+                )
+
+            return func
+
+        return decorator

--- a/pyrogram/methods/decorators/on_ephemeral_callback_query.py
+++ b/pyrogram/methods/decorators/on_ephemeral_callback_query.py
@@ -1,0 +1,63 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Callable, Optional, Union
+
+import pyrogram
+from pyrogram.filters import Filter
+
+
+class OnEphemeralCallbackQuery:
+    def on_ephemeral_callback_query(
+        self: Union["OnEphemeralCallbackQuery", Filter, None] = None,
+        filters: Optional[Filter] = None,
+        group: int = 0,
+    ) -> Callable:
+        """Decorator for handling callback queries coming from ephemeral messages.
+
+        This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
+        :obj:`~pyrogram.handlers.EphemeralCallbackQueryHandler`.
+
+        .. include:: /_includes/usable-by/bots.rst
+
+        Parameters:
+            filters (:obj:`~pyrogram.filters`, *optional*):
+                Pass one or more filters to allow only a subset of callback queries to be passed
+                in your function.
+
+            group (``int``, *optional*):
+                The group identifier, defaults to 0.
+        """
+
+        def decorator(func: Callable) -> Callable:
+            if isinstance(self, pyrogram.Client):
+                self.add_handler(pyrogram.handlers.EphemeralCallbackQueryHandler(func, filters), group)
+            elif isinstance(self, Filter) or self is None:
+                if not hasattr(func, "handlers"):
+                    func.handlers = []
+
+                func.handlers.append(
+                    (
+                        pyrogram.handlers.EphemeralCallbackQueryHandler(func, self),
+                        group if filters is None else filters
+                    )
+                )
+
+            return func
+
+        return decorator

--- a/pyrogram/methods/decorators/on_ephemeral_message.py
+++ b/pyrogram/methods/decorators/on_ephemeral_message.py
@@ -1,0 +1,63 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Callable, Optional, Union
+
+import pyrogram
+from pyrogram.filters import Filter
+
+
+class OnEphemeralMessage:
+    def on_ephemeral_message(
+        self: Union["OnEphemeralMessage", Filter, None] = None,
+        filters: Optional[Filter] = None,
+        group: int = 0,
+    ) -> Callable:
+        """Decorator for handling new ephemeral messages.
+
+        This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
+        :obj:`~pyrogram.handlers.EphemeralMessageHandler`.
+
+        .. include:: /_includes/usable-by/bots.rst
+
+        Parameters:
+            filters (:obj:`~pyrogram.filters`, *optional*):
+                Pass one or more filters to allow only a subset of messages to be passed
+                in your function.
+
+            group (``int``, *optional*):
+                The group identifier, defaults to 0.
+        """
+
+        def decorator(func: Callable) -> Callable:
+            if isinstance(self, pyrogram.Client):
+                self.add_handler(pyrogram.handlers.EphemeralMessageHandler(func, filters), group)
+            elif isinstance(self, Filter) or self is None:
+                if not hasattr(func, "handlers"):
+                    func.handlers = []
+
+                func.handlers.append(
+                    (
+                        pyrogram.handlers.EphemeralMessageHandler(func, self),
+                        group if filters is None else filters
+                    )
+                )
+
+            return func
+
+        return decorator

--- a/pyrogram/methods/messages/__init__.py
+++ b/pyrogram/methods/messages/__init__.py
@@ -26,9 +26,12 @@ from .copy_message import CopyMessage
 from .decline_suggested_post import DeclineSuggestedPost
 from .delete_chat_history import DeleteChatHistory
 from .delete_direct_messages_chat_topic_history import DeleteDirectMessagesChatTopicHistory
+from .delete_ephemeral_messages import DeleteEphemeralMessages
 from .delete_messages import DeleteMessages
 from .delete_poll_option import DeletePollOption
 from .download_media import DownloadMedia
+from .edit_ephemeral_message_media import EditEphemeralMessageMedia
+from .edit_ephemeral_message_text import EditEphemeralMessageText
 from .edit_inline_caption import EditInlineCaption
 from .edit_inline_media import EditInlineMedia
 from .edit_inline_reply_markup import EditInlineReplyMarkup
@@ -62,6 +65,7 @@ from .open_web_app import OpenWebApp
 from .read_chat_history import ReadChatHistory
 from .read_mentions import ReadMentions
 from .read_reactions import ReadReactions
+from .report_ephemeral_message import ReportEphemeralMessage
 from .retract_vote import RetractVote
 from .search_global import SearchGlobal
 from .search_global_count import SearchGlobalCount
@@ -77,6 +81,7 @@ from .send_checklist import SendChecklist
 from .send_contact import SendContact
 from .send_dice import SendDice
 from .send_document import SendDocument
+from .send_ephemeral_message import SendEphemeralMessage
 from .send_location import SendLocation
 from .send_media_group import SendMediaGroup
 from .send_message_draft import SendMessageDraft
@@ -113,8 +118,11 @@ class Messages(
     ApproveSuggestedPost,
     ComposeTextWithAI,
     DeclineSuggestedPost,
+    DeleteEphemeralMessages,
     DeleteMessages,
     DeletePollOption,
+    EditEphemeralMessageMedia,
+    EditEphemeralMessageText,
     EditMessageCaption,
     EditMessageChecklist,
     EditMessageReplyMarkup,
@@ -138,6 +146,7 @@ class Messages(
     SendChecklist,
     SendContact,
     SendDocument,
+    SendEphemeralMessage,
     SendAnimation,
     SendLocation,
     SendMediaGroup,
@@ -194,6 +203,7 @@ class Messages(
     TranslateMessageText,
     TranslateText,
     GetCustomEmojiStickers,
-    GetDirectMessagesChatTopicHistory
+    GetDirectMessagesChatTopicHistory,
+    ReportEphemeralMessage
 ):
     pass

--- a/pyrogram/methods/messages/delete_ephemeral_messages.py
+++ b/pyrogram/methods/messages/delete_ephemeral_messages.py
@@ -1,0 +1,74 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Iterable, Union
+
+import pyrogram
+from pyrogram import raw, utils
+
+
+class DeleteEphemeralMessages:
+    async def delete_ephemeral_messages(
+        self: "pyrogram.Client",
+        chat_id: Union[int, str],
+        receiver_id: Union[int, str],
+        message_ids: Union[int, Iterable[int]],
+    ) -> bool:
+        """Delete one or more ephemeral messages.
+
+        .. include:: /_includes/usable-by/bots.rst
+
+        Parameters:
+            chat_id (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the target chat.
+
+            receiver_id (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the only user allowed to see this
+                message.
+
+            message_ids (``int`` | Iterable of ``int``):
+                An iterable of message identifiers to delete (integers) or a single message id.
+
+        Returns:
+            ``bool``: True on success.
+
+        Example:
+            .. code-block:: python
+
+                # Delete one message
+                await app.delete_ephemeral_messages(chat_id, receiver_id, message_id)
+
+                # Delete multiple messages at once
+                await app.delete_ephemeral_messages(chat_id, receiver_id, list_of_message_ids)
+        """
+        is_iterable = not isinstance(message_ids, int)
+        message_ids = list(message_ids) if is_iterable else [message_ids]
+
+        peer = await self.resolve_peer(chat_id)
+        receiver = await utils.resolve_receiver(self, receiver_id)
+
+        for message_id in message_ids:
+            await self.invoke(
+                raw.functions.ephemeral.DeleteMessage(
+                    peer=peer,
+                    receiver_id=receiver,
+                    id=message_id,
+                )
+            )
+
+        return True

--- a/pyrogram/methods/messages/edit_ephemeral_message_media.py
+++ b/pyrogram/methods/messages/edit_ephemeral_message_media.py
@@ -1,0 +1,82 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+from typing import Union
+
+import pyrogram
+from pyrogram import raw, types, utils
+
+log = logging.getLogger(__name__)
+
+
+class EditEphemeralMessageMedia:
+    async def edit_ephemeral_message_media(
+        self: "pyrogram.Client",
+        chat_id: Union[int, str],
+        receiver_id: Union[int, str],
+        message_id: int,
+        media: "types.InputMedia",
+        reply_markup: "types.InlineKeyboardMarkup" = None,
+    ) -> "types.EphemeralMessage":
+        """Edit the media of an ephemeral message.
+
+        .. include:: /_includes/usable-by/bots.rst
+
+        Parameters:
+            chat_id (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the target chat.
+
+            receiver_id (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the only user allowed to see this
+                message.
+
+            message_id (``int``):
+                Identifier of the ephemeral message to edit.
+
+            media (:obj:`~pyrogram.types.InputMedia`):
+                One of the InputMedia objects describing an animation, audio, document, photo or
+                video.
+
+            reply_markup (:obj:`~pyrogram.types.InlineKeyboardMarkup`, *optional*):
+                An InlineKeyboardMarkup object.
+
+        Returns:
+            :obj:`~pyrogram.types.EphemeralMessage`: On success, the edited message is returned.
+
+        Example:
+            .. code-block:: python
+
+                from pyrogram import types
+
+                await app.edit_ephemeral_message_media(
+                    chat_id, receiver_id, message_id,
+                    types.InputMediaPhoto("new_photo.jpg")
+                )
+        """
+        r = await self.invoke(
+            raw.functions.ephemeral.EditMessage(
+                peer=await self.resolve_peer(chat_id),
+                receiver_id=await utils.resolve_receiver(self, receiver_id),
+                id=message_id,
+                media=await media.write(self),
+                reply_markup=await reply_markup.write(self) if reply_markup else None,
+            )
+        )
+
+        return await utils.parse_ephemeral_message(self, r)

--- a/pyrogram/methods/messages/edit_ephemeral_message_media.py
+++ b/pyrogram/methods/messages/edit_ephemeral_message_media.py
@@ -74,7 +74,7 @@ class EditEphemeralMessageMedia:
                 peer=await self.resolve_peer(chat_id),
                 receiver_id=await utils.resolve_receiver(self, receiver_id),
                 id=message_id,
-                media=await media.write(self),
+                media=await media.write(client=self),
                 reply_markup=await reply_markup.write(self) if reply_markup else None,
             )
         )

--- a/pyrogram/methods/messages/edit_ephemeral_message_text.py
+++ b/pyrogram/methods/messages/edit_ephemeral_message_text.py
@@ -1,0 +1,89 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+from typing import List, Optional, Union
+
+import pyrogram
+from pyrogram import enums, raw, types, utils
+
+log = logging.getLogger(__name__)
+
+
+class EditEphemeralMessageText:
+    async def edit_ephemeral_message_text(
+        self: "pyrogram.Client",
+        chat_id: Union[int, str],
+        receiver_id: Union[int, str],
+        message_id: int,
+        text: str,
+        parse_mode: Optional["enums.ParseMode"] = None,
+        entities: Optional[List["types.MessageEntity"]] = None,
+        reply_markup: "types.InlineKeyboardMarkup" = None,
+    ) -> "types.EphemeralMessage":
+        """Edit the text of an ephemeral message.
+
+        .. include:: /_includes/usable-by/bots.rst
+
+        Parameters:
+            chat_id (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the target chat.
+
+            receiver_id (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the only user allowed to see this
+                message.
+
+            message_id (``int``):
+                Identifier of the ephemeral message to edit.
+
+            text (``str``):
+                New text of the message.
+
+            parse_mode (:obj:`~pyrogram.enums.ParseMode`, *optional*):
+                By default, texts are parsed using both Markdown and HTML styles.
+                You can combine both syntaxes together.
+
+            entities (List of :obj:`~pyrogram.types.MessageEntity`, *optional*):
+                List of special entities that appear in message text, which can be specified
+                instead of *parse_mode*.
+
+            reply_markup (:obj:`~pyrogram.types.InlineKeyboardMarkup`, *optional*):
+                An InlineKeyboardMarkup object.
+
+        Returns:
+            :obj:`~pyrogram.types.EphemeralMessage`: On success, the edited message is returned.
+
+        Example:
+            .. code-block:: python
+
+                await app.edit_ephemeral_message_text(chat_id, receiver_id, message_id, "new text")
+        """
+        message, entities = (await utils.parse_text_entities(self, text, parse_mode, entities)).values()
+
+        r = await self.invoke(
+            raw.functions.ephemeral.EditMessage(
+                peer=await self.resolve_peer(chat_id),
+                receiver_id=await utils.resolve_receiver(self, receiver_id),
+                id=message_id,
+                message=message,
+                entities=entities,
+                reply_markup=await reply_markup.write(self) if reply_markup else None,
+            )
+        )
+
+        return await utils.parse_ephemeral_message(self, r)

--- a/pyrogram/methods/messages/report_ephemeral_message.py
+++ b/pyrogram/methods/messages/report_ephemeral_message.py
@@ -1,0 +1,67 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Union
+
+import pyrogram
+from pyrogram import raw
+
+
+class ReportEphemeralMessage:
+    async def report_ephemeral_message(
+        self: "pyrogram.Client",
+        chat_id: Union[int, str],
+        message_id: int,
+        option: bytes,
+        message: str = "",
+    ) -> "raw.base.ReportResult":
+        """Report an ephemeral message for violating Telegram's Terms of Service.
+
+        .. include:: /_includes/usable-by/bots.rst
+
+        Parameters:
+            chat_id (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the target chat.
+
+            message_id (``int``):
+                Identifier of the ephemeral message to report.
+
+            option (``bytes``):
+                The option chosen from a previously received :obj:`~pyrogram.raw.base.ReportResult`.
+                Pass an empty ``bytes`` object to obtain the initial set of options.
+
+            message (``str``, *optional*):
+                An optional free-form message describing the report.
+
+        Returns:
+            :obj:`~pyrogram.raw.base.ReportResult`: The follow-up report options, or the final
+            report result.
+
+        Example:
+            .. code-block:: python
+
+                await app.report_ephemeral_message(chat_id, message_id, option=b"")
+        """
+        return await self.invoke(
+            raw.functions.ephemeral.ReportMessage(
+                peer=await self.resolve_peer(chat_id),
+                id=message_id,
+                option=option,
+                message=message,
+            )
+        )

--- a/pyrogram/methods/messages/send_ephemeral_message.py
+++ b/pyrogram/methods/messages/send_ephemeral_message.py
@@ -1,0 +1,109 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+from typing import List, Optional, Union
+
+import pyrogram
+from pyrogram import enums, raw, types, utils
+
+log = logging.getLogger(__name__)
+
+
+class SendEphemeralMessage:
+    async def send_ephemeral_message(
+        self: "pyrogram.Client",
+        chat_id: Union[int, str],
+        receiver_id: Union[int, str],
+        text: str = "",
+        parse_mode: Optional["enums.ParseMode"] = None,
+        entities: Optional[List["types.MessageEntity"]] = None,
+        media: Optional["types.InputMedia"] = None,
+        reply_to_message_id: Optional[int] = None,
+        reply_markup: Optional[Union[
+            "types.InlineKeyboardMarkup",
+            "types.ReplyKeyboardMarkup",
+            "types.ReplyKeyboardRemove",
+            "types.ForceReply"
+        ]] = None,
+    ) -> "types.EphemeralMessage":
+        """Send an ephemeral message.
+
+        Ephemeral messages are lightweight messages that only the ``receiver_id`` user can see.
+        They don't become part of the regular chat history and can't be forwarded or fetched later
+        with :meth:`~pyrogram.Client.get_messages`.
+
+        .. include:: /_includes/usable-by/bots.rst
+
+        Parameters:
+            chat_id (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the target chat.
+
+            receiver_id (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the only user allowed to see this
+                message.
+
+            text (``str``, *optional*):
+                Text of the message to be sent.
+
+            parse_mode (:obj:`~pyrogram.enums.ParseMode`, *optional*):
+                By default, texts are parsed using both Markdown and HTML styles.
+                You can combine both syntaxes together.
+
+            entities (List of :obj:`~pyrogram.types.MessageEntity`, *optional*):
+                List of special entities that appear in message text, which can be specified
+                instead of *parse_mode*.
+
+            media (:obj:`~pyrogram.types.InputMedia`, *optional*):
+                Media to attach to the message.
+
+            reply_to_message_id (``int``, *optional*):
+                If the message is a reply, the id of the ephemeral message it replies to.
+
+            reply_markup (:obj:`~pyrogram.types.InlineKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardRemove` | :obj:`~pyrogram.types.ForceReply`, *optional*):
+                Additional interface options. An object for an inline keyboard, custom reply keyboard,
+                instructions to remove reply keyboard or to force a reply from the user.
+
+        Returns:
+            :obj:`~pyrogram.types.EphemeralMessage`: On success, the sent ephemeral message is returned.
+
+        Example:
+            .. code-block:: python
+
+                await app.send_ephemeral_message(chat_id, receiver_id, "This message will vanish!")
+        """
+        message, entities = (await utils.parse_text_entities(self, text, parse_mode, entities)).values()
+
+        r = await self.invoke(
+            raw.functions.ephemeral.SendMessage(
+                peer=await self.resolve_peer(chat_id),
+                receiver_id=await utils.resolve_receiver(self, receiver_id),
+                message=message,
+                random_id=self.rnd_id(),
+                entities=entities,
+                media=await media.write(self) if media else None,
+                reply_markup=await reply_markup.write(self) if reply_markup else None,
+                reply_to=(
+                    raw.types.InputReplyToEphemeralMessage(id=reply_to_message_id)
+                    if reply_to_message_id
+                    else None
+                ),
+            )
+        )
+
+        return await utils.parse_ephemeral_message(self, r)

--- a/pyrogram/methods/messages/send_ephemeral_message.py
+++ b/pyrogram/methods/messages/send_ephemeral_message.py
@@ -96,7 +96,7 @@ class SendEphemeralMessage:
                 message=message,
                 random_id=self.rnd_id(),
                 entities=entities,
-                media=await media.write(self) if media else None,
+                media=await media.write(client=self) if media else None,
                 reply_markup=await reply_markup.write(self) if reply_markup else None,
                 reply_to=(
                     raw.types.InputReplyToEphemeralMessage(id=reply_to_message_id)

--- a/pyrogram/methods/messages/send_ephemeral_message.py
+++ b/pyrogram/methods/messages/send_ephemeral_message.py
@@ -34,19 +34,27 @@ class SendEphemeralMessage:
         parse_mode: Optional["enums.ParseMode"] = None,
         entities: Optional[List["types.MessageEntity"]] = None,
         media: Optional["types.InputMedia"] = None,
-        reply_to_message_id: Optional[int] = None,
+        callback_query_id: Optional[int] = None,
+        reply_parameters: Optional["types.ReplyParameters"] = None,
         reply_markup: Optional[Union[
             "types.InlineKeyboardMarkup",
             "types.ReplyKeyboardMarkup",
             "types.ReplyKeyboardRemove",
             "types.ForceReply"
         ]] = None,
+        reply_to_message_id: Optional[int] = None,
     ) -> "types.EphemeralMessage":
         """Send an ephemeral message.
 
         Ephemeral messages are lightweight messages that only the ``receiver_id`` user can see.
         They don't become part of the regular chat history and can't be forwarded or fetched later
         with :meth:`~pyrogram.Client.get_messages`.
+
+        A bot may send an ephemeral message to a user within 15 seconds of an eligible incoming
+        action only by providing either ``callback_query_id`` (from a received callback query) or
+        ``reply_parameters.ephemeral_message_id`` (from an incoming ephemeral message/command). If
+        the bot is an administrator of the chat, it can send an ephemeral message to any non-bot
+        member at any time without either of these.
 
         .. include:: /_includes/usable-by/bots.rst
 
@@ -72,12 +80,27 @@ class SendEphemeralMessage:
             media (:obj:`~pyrogram.types.InputMedia`, *optional*):
                 Media to attach to the message.
 
-            reply_to_message_id (``int``, *optional*):
-                If the message is a reply, the id of the ephemeral message it replies to.
+            callback_query_id (``int``, *optional*):
+                Identifier of the callback query that triggered this response, obtained from
+                :obj:`~pyrogram.types.CallbackQuery.id` or
+                :obj:`~pyrogram.types.EphemeralCallbackQuery.id`. The message will be delivered to
+                the exact client application that triggered the callback query. Required (unless
+                the bot is a chat administrator) if ``reply_parameters.ephemeral_message_id`` isn't
+                provided.
+
+            reply_parameters (:obj:`~pyrogram.types.ReplyParameters`, *optional*):
+                Describes the message to reply to. Pass
+                ``ReplyParameters(ephemeral_message_id=...)`` to reply to an incoming ephemeral
+                message/command; this also satisfies the 15-second reply-authorization requirement
+                for non-administrator bots.
 
             reply_markup (:obj:`~pyrogram.types.InlineKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardMarkup` | :obj:`~pyrogram.types.ReplyKeyboardRemove` | :obj:`~pyrogram.types.ForceReply`, *optional*):
                 Additional interface options. An object for an inline keyboard, custom reply keyboard,
                 instructions to remove reply keyboard or to force a reply from the user.
+
+            reply_to_message_id (``int``, *optional*):
+                Deprecated in favor of *reply_parameters*. If the message is a reply, the id of the
+                ephemeral message it replies to.
 
         Returns:
             :obj:`~pyrogram.types.EphemeralMessage`: On success, the sent ephemeral message is returned.
@@ -85,8 +108,27 @@ class SendEphemeralMessage:
         Example:
             .. code-block:: python
 
-                await app.send_ephemeral_message(chat_id, receiver_id, "This message will vanish!")
+                # Reply to a callback query with an ephemeral message
+                await app.send_ephemeral_message(
+                    chat_id, receiver_id, "This message will vanish!",
+                    callback_query_id=callback_query.id
+                )
+
+                # Reply to an incoming ephemeral message/command
+                await app.send_ephemeral_message(
+                    chat_id, receiver_id, "This message will vanish!",
+                    reply_parameters=types.ReplyParameters(ephemeral_message_id=message.id)
+                )
         """
+        if reply_to_message_id is not None:
+            log.warning(
+                "`reply_to_message_id` is deprecated and will be removed in future updates. "
+                "Use `reply_parameters` instead."
+            )
+
+            if reply_parameters is None:
+                reply_parameters = types.ReplyParameters(ephemeral_message_id=reply_to_message_id)
+
         message, entities = (await utils.parse_text_entities(self, text, parse_mode, entities)).values()
 
         r = await self.invoke(
@@ -95,14 +137,11 @@ class SendEphemeralMessage:
                 receiver_id=await utils.resolve_receiver(self, receiver_id),
                 message=message,
                 random_id=self.rnd_id(),
+                query_id=callback_query_id,
                 entities=entities,
                 media=await media.write(client=self) if media else None,
                 reply_markup=await reply_markup.write(self) if reply_markup else None,
-                reply_to=(
-                    raw.types.InputReplyToEphemeralMessage(id=reply_to_message_id)
-                    if reply_to_message_id
-                    else None
-                ),
+                reply_to=await utils.get_reply_to(self, reply_parameters),
             )
         )
 

--- a/pyrogram/types/bots_and_keyboards/__init__.py
+++ b/pyrogram/types/bots_and_keyboards/__init__.py
@@ -29,6 +29,7 @@ from .bot_command_scope_default import BotCommandScopeDefault
 from .callback_game import CallbackGame
 from .callback_query import CallbackQuery
 from .chat_boost_updated import ChatBoostUpdated
+from .ephemeral_callback_query import EphemeralCallbackQuery
 from .force_reply import ForceReply
 from .game_high_score import GameHighScore
 from .inline_keyboard_button import InlineKeyboardButton
@@ -66,6 +67,7 @@ __all__ = [
     "CallbackGame",
     "CallbackQuery",
     "ChatBoostUpdated",
+    "EphemeralCallbackQuery",
     "ForceReply",
     "GameHighScore",
     "InlineKeyboardButton",

--- a/pyrogram/types/bots_and_keyboards/bot_command.py
+++ b/pyrogram/types/bots_and_keyboards/bot_command.py
@@ -31,23 +31,30 @@ class BotCommand(Object):
 
         description (``str``):
             Description of the command; 1-256 characters.
+
+        is_ephemeral (``bool``, *optional*):
+            True, if the command sends an ephemeral message, which can be seen only by the sender
+            of the message and the bot.
     """
 
-    def __init__(self, command: str, description: str):
+    def __init__(self, command: str, description: str, is_ephemeral: bool = None):
         super().__init__()
 
         self.command = command
         self.description = description
+        self.is_ephemeral = is_ephemeral
 
     def write(self) -> "raw.types.BotCommand":
         return raw.types.BotCommand(
             command=self.command,
             description=self.description,
+            ephemeral=self.is_ephemeral,
         )
 
     @staticmethod
     def read(c: "raw.types.BotCommand") -> "BotCommand":
         return BotCommand(
             command=c.command,
-            description=c.description
+            description=c.description,
+            is_ephemeral=c.ephemeral,
         )

--- a/pyrogram/types/bots_and_keyboards/ephemeral_callback_query.py
+++ b/pyrogram/types/bots_and_keyboards/ephemeral_callback_query.py
@@ -1,0 +1,160 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+from typing import List, Match, Optional, Union
+
+import pyrogram
+from pyrogram import raw, types
+
+from ..object import Object
+from ..update import Update
+
+log = logging.getLogger(__name__)
+
+
+class EphemeralCallbackQuery(Object, Update):
+    """An incoming callback query from a callback button attached to an ephemeral message.
+
+    Parameters:
+        id (``str``):
+            Unique identifier for this query.
+
+        from_user (:obj:`~pyrogram.types.User`):
+            Sender.
+
+        message (:obj:`~pyrogram.types.EphemeralMessage`, *optional*):
+            The ephemeral message with the callback button that originated the query.
+
+        data (``str`` | ``bytes``, *optional*):
+            Data associated with the callback button. Be aware that a bad client can send arbitrary
+            data in this field.
+
+        matches (List of regex Matches, *optional*):
+            A list containing all `Match Objects <https://docs.python.org/3/library/re.html#match-objects>`_
+            that match the data of this callback query. Only applicable when using
+            :obj:`Filters.regex <pyrogram.Filters.regex>`.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: "pyrogram.Client" = None,
+        id: str,
+        from_user: "types.User",
+        message: "types.EphemeralMessage" = None,
+        data: Union[str, bytes] = None,
+        matches: List[Match] = None
+    ):
+        super().__init__(client)
+
+        self.id = id
+        self.from_user = from_user
+        self.message = message
+        self.data = data
+        self.matches = matches
+
+    @staticmethod
+    async def _parse(
+        client: "pyrogram.Client",
+        update: "raw.types.UpdateEphemeralBotCallbackQuery",
+        users,
+        chats,
+    ) -> "EphemeralCallbackQuery":
+        data = getattr(update, "data", None)
+
+        if data:
+            try:
+                data = data.decode()
+            except (UnicodeDecodeError, AttributeError):
+                pass
+
+        return EphemeralCallbackQuery(
+            id=str(update.query_id),
+            from_user=types.User._parse(client, users.get(update.user_id)),
+            message=await types.EphemeralMessage._parse(client, update.message, users, chats),
+            data=data,
+            client=client,
+        )
+
+    async def answer(self, text: str = None, show_alert: bool = None, url: str = None, cache_time: int = 0):
+        """Bound method *answer* of :obj:`~pyrogram.types.EphemeralCallbackQuery`.
+
+        Use this method as a shortcut for:
+
+        .. code-block:: python
+
+            await client.answer_callback_query(
+                ephemeral_callback_query.id,
+                text="Hello",
+                show_alert=True
+            )
+
+        Parameters:
+            text (``str``, *optional*):
+                Text of the notification. If not specified, nothing will be shown to the user.
+
+            show_alert (``bool`` *optional*):
+                If true, an alert will be shown by the client instead of a notification at the top of
+                the chat screen.
+
+            url (``str`` *optional*):
+                URL that will be opened by the user's client.
+
+            cache_time (``int`` *optional*):
+                The maximum amount of time in seconds that the result of the callback query may be
+                cached client-side.
+        """
+        return await self._client.answer_callback_query(
+            callback_query_id=self.id,
+            text=text,
+            show_alert=show_alert,
+            url=url,
+            cache_time=cache_time
+        )
+
+    async def edit_message_text(
+        self,
+        text: str,
+        entities: List["types.MessageEntity"] = None,
+        reply_markup: "types.InlineKeyboardMarkup" = None,
+    ) -> "types.EphemeralMessage":
+        """Bound method *edit_message_text* of :obj:`~pyrogram.types.EphemeralCallbackQuery`.
+
+        Use this method as a shortcut for:
+
+        .. code-block:: python
+
+            await client.edit_ephemeral_message_text(
+                chat_id=ephemeral_callback_query.message.chat.id,
+                receiver_id=ephemeral_callback_query.message.receiver.id,
+                message_id=ephemeral_callback_query.message.id,
+                text="new text"
+            )
+
+        Returns:
+            :obj:`~pyrogram.types.EphemeralMessage`: On success, the edited message is returned.
+        """
+        return await self._client.edit_ephemeral_message_text(
+            chat_id=self.message.chat.id,
+            receiver_id=self.message.receiver.id,
+            message_id=self.message.id,
+            text=text,
+            entities=entities,
+            reply_markup=reply_markup,
+        )

--- a/pyrogram/types/messages_and_media/__init__.py
+++ b/pyrogram/types/messages_and_media/__init__.py
@@ -45,6 +45,7 @@ from .dice import Dice
 from .direct_message_price_changed import DirectMessagePriceChanged
 from .direct_messages_topic import DirectMessagesTopic
 from .document import Document
+from .ephemeral_message import EphemeralMessage
 from .external_reply_info import ExternalReplyInfo
 from .fact_check import FactCheck
 from .formatted_text import FormattedText
@@ -248,6 +249,7 @@ __all__ = [
     "DirectMessagePriceChanged",
     "DirectMessagesTopic",
     "Document",
+    "EphemeralMessage",
     "ExternalReplyInfo",
     "FactCheck",
     "FormattedText",

--- a/pyrogram/types/messages_and_media/ephemeral_message.py
+++ b/pyrogram/types/messages_and_media/ephemeral_message.py
@@ -345,7 +345,7 @@ class EphemeralMessage(Object, Update):
                 chat_id=message.chat.id,
                 receiver_id=message.receiver.id,
                 text="hello",
-                reply_to_message_id=message.id
+                reply_parameters=types.ReplyParameters(ephemeral_message_id=message.id)
             )
 
         Example:
@@ -377,7 +377,7 @@ class EphemeralMessage(Object, Update):
             entities=entities,
             media=media,
             reply_markup=reply_markup,
-            reply_to_message_id=self.id,
+            reply_parameters=types.ReplyParameters(ephemeral_message_id=self.id),
         )
 
     async def edit_text(

--- a/pyrogram/types/messages_and_media/ephemeral_message.py
+++ b/pyrogram/types/messages_and_media/ephemeral_message.py
@@ -1,0 +1,521 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+from datetime import datetime
+from typing import Dict, List, Optional, Union
+
+import pyrogram
+from pyrogram import enums, raw, types, utils
+
+from ..object import Object
+from ..update import Update
+from .message import Str
+
+log = logging.getLogger(__name__)
+
+
+class EphemeralMessage(Object, Update):
+    """An ephemeral message.
+
+    Ephemeral messages are lightweight, transient messages exchanged between a bot and a single
+    receiving user. Unlike regular messages, they are not part of the chat history: they can't be
+    forwarded, searched or fetched later on, and only exist for as long as Telegram keeps them around.
+
+    Parameters:
+        id (``int``):
+            Unique identifier of the ephemeral message.
+
+        from_user (:obj:`~pyrogram.types.User`, *optional*):
+            Sender of the message.
+
+        chat (:obj:`~pyrogram.types.Chat`, *optional*):
+            Conversation the message was exchanged in.
+
+        receiver (:obj:`~pyrogram.types.User`, *optional*):
+            The only user allowed to see this message.
+
+        date (:py:obj:`~datetime.datetime`, *optional*):
+            Date the message was sent.
+
+        outgoing (``bool``, *optional*):
+            True, if the message is outgoing.
+
+        message_thread_id (``int``, *optional*):
+            Unique identifier of the forum topic the message belongs to, for forums only.
+
+        text (``str``, *optional*):
+            Text of the message, for text messages.
+
+        caption (``str``, *optional*):
+            Caption for the media, for media messages.
+
+        entities (List of :obj:`~pyrogram.types.MessageEntity`, *optional*):
+            For text messages, special entities like usernames, URLs, bot commands, etc. that appear
+            in the text.
+
+        caption_entities (List of :obj:`~pyrogram.types.MessageEntity`, *optional*):
+            For messages with a caption, special entities like usernames, URLs, bot commands, etc.
+            that appear in the caption.
+
+        media (:obj:`~pyrogram.enums.MessageMediaType`, *optional*):
+            The media type of the message, if it is a media message.
+
+        photo (:obj:`~pyrogram.types.Photo`, *optional*):
+            Message is a photo, information about the photo.
+
+        animation (:obj:`~pyrogram.types.Animation`, *optional*):
+            Message is an animation, information about the animation.
+
+        audio (:obj:`~pyrogram.types.Audio`, *optional*):
+            Message is an audio file, information about the file.
+
+        document (:obj:`~pyrogram.types.Document`, *optional*):
+            Message is a general file, information about the file.
+
+        sticker (:obj:`~pyrogram.types.Sticker`, *optional*):
+            Message is a sticker, information about the sticker.
+
+        video (:obj:`~pyrogram.types.Video`, *optional*):
+            Message is a video, information about the video.
+
+        video_note (:obj:`~pyrogram.types.VideoNote`, *optional*):
+            Message is a video note, information about the video message.
+
+        voice (:obj:`~pyrogram.types.Voice`, *optional*):
+            Message is a voice message, information about the file.
+
+        has_media_spoiler (``bool``, *optional*):
+            True, if the message media is covered by a spoiler animation.
+
+        reply_markup (:obj:`~pyrogram.types.InlineKeyboardMarkup`, *optional*):
+            Additional interface options attached to the message.
+
+        reply_to_message_id (``int``, *optional*):
+            The id of the ephemeral message this message is replying to, if any.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: "pyrogram.Client" = None,
+        id: int,
+        from_user: "types.User" = None,
+        chat: "types.Chat" = None,
+        receiver: "types.User" = None,
+        date: datetime = None,
+        outgoing: bool = None,
+        message_thread_id: int = None,
+        text: Str = None,
+        caption: Str = None,
+        entities: List["types.MessageEntity"] = None,
+        caption_entities: List["types.MessageEntity"] = None,
+        media: "enums.MessageMediaType" = None,
+        photo: "types.Photo" = None,
+        animation: "types.Animation" = None,
+        audio: "types.Audio" = None,
+        document: "types.Document" = None,
+        sticker: "types.Sticker" = None,
+        video: "types.Video" = None,
+        video_note: "types.VideoNote" = None,
+        voice: "types.Voice" = None,
+        has_media_spoiler: bool = None,
+        reply_markup: Union[
+            "types.InlineKeyboardMarkup",
+            "types.ReplyKeyboardMarkup",
+            "types.ReplyKeyboardRemove",
+            "types.ForceReply",
+        ] = None,
+        reply_to_message_id: int = None,
+        raw: "raw.types.EphemeralMessage" = None,
+    ):
+        super().__init__(client)
+
+        self.id = id
+        self.from_user = from_user
+        self.chat = chat
+        self.receiver = receiver
+        self.date = date
+        self.outgoing = outgoing
+        self.message_thread_id = message_thread_id
+        self.text = text
+        self.caption = caption
+        self.entities = entities
+        self.caption_entities = caption_entities
+        self.media = media
+        self.photo = photo
+        self.animation = animation
+        self.audio = audio
+        self.document = document
+        self.sticker = sticker
+        self.video = video
+        self.video_note = video_note
+        self.voice = voice
+        self.has_media_spoiler = has_media_spoiler
+        self.reply_markup = reply_markup
+        self.reply_to_message_id = reply_to_message_id
+        self.raw = raw
+
+    @staticmethod
+    async def _parse(
+        client: "pyrogram.Client",
+        message: "raw.types.EphemeralMessage",
+        users: Dict[int, "raw.base.User"],
+        chats: Dict[int, "raw.base.Chat"],
+    ) -> "EphemeralMessage":
+        entities = types.List(
+            filter(
+                lambda x: x is not None,
+                [types.MessageEntity._parse(client, entity, users) for entity in message.entities or []]
+            )
+        )
+
+        media_type = None
+        media = message.media
+        photo = None
+        animation = None
+        audio = None
+        document = None
+        sticker = None
+        video = None
+        video_note = None
+        voice = None
+        has_media_spoiler = None
+
+        if media:
+            if isinstance(media, raw.types.MessageMediaPhoto):
+                media_type = enums.MessageMediaType.PHOTO
+                photo = types.Photo._parse(client, media.photo, media.ttl_seconds)
+                has_media_spoiler = media.spoiler
+            elif isinstance(media, raw.types.MessageMediaDocument):
+                doc = media.document
+                has_media_spoiler = media.spoiler
+
+                if isinstance(doc, raw.types.Document):
+                    attributes = {type(i): i for i in doc.attributes}
+
+                    file_name = getattr(
+                        attributes.get(raw.types.DocumentAttributeFilename, None),
+                        "file_name",
+                        None
+                    )
+
+                    if raw.types.DocumentAttributeAnimated in attributes:
+                        video_attributes = attributes.get(raw.types.DocumentAttributeVideo, None)
+                        animation = types.Animation._parse(client, doc, video_attributes, file_name)
+                        media_type = enums.MessageMediaType.ANIMATION
+                    elif raw.types.DocumentAttributeSticker in attributes:
+                        sticker = await types.Sticker._parse(client, doc, attributes)
+                        media_type = enums.MessageMediaType.STICKER
+                    elif raw.types.DocumentAttributeVideo in attributes:
+                        video_attributes = attributes[raw.types.DocumentAttributeVideo]
+
+                        if video_attributes.round_message:
+                            video_note = types.VideoNote._parse(client, doc, video_attributes, media.ttl_seconds)
+                            media_type = enums.MessageMediaType.VIDEO_NOTE
+                        else:
+                            video = types.Video._parse(
+                                client, doc, video_attributes, file_name, media.ttl_seconds,
+                                getattr(media, "video_cover", None),
+                                getattr(media, "video_timestamp", None),
+                                getattr(media, "alt_documents", None),
+                            )
+                            media_type = enums.MessageMediaType.VIDEO
+                    elif raw.types.DocumentAttributeAudio in attributes:
+                        audio_attributes = attributes[raw.types.DocumentAttributeAudio]
+
+                        if audio_attributes.voice:
+                            voice = types.Voice._parse(client, doc, audio_attributes, media.ttl_seconds)
+                            media_type = enums.MessageMediaType.VOICE
+                        else:
+                            audio = types.Audio._parse(client, doc, audio_attributes, file_name)
+                            media_type = enums.MessageMediaType.AUDIO
+                    else:
+                        document = types.Document._parse(client, doc, file_name)
+                        media_type = enums.MessageMediaType.DOCUMENT
+            else:
+                media_type = enums.MessageMediaType.UNSUPPORTED
+                media = None
+
+        reply_markup = message.reply_markup
+
+        if reply_markup:
+            if isinstance(reply_markup, raw.types.ReplyKeyboardForceReply):
+                reply_markup = types.ForceReply.read(reply_markup)
+            elif isinstance(reply_markup, raw.types.ReplyKeyboardMarkup):
+                reply_markup = types.ReplyKeyboardMarkup.read(reply_markup)
+            elif isinstance(reply_markup, raw.types.ReplyInlineMarkup):
+                reply_markup = types.InlineKeyboardMarkup.read(reply_markup)
+            elif isinstance(reply_markup, raw.types.ReplyKeyboardHide):
+                reply_markup = types.ReplyKeyboardRemove.read(reply_markup)
+            else:
+                reply_markup = None
+
+        return EphemeralMessage(
+            id=message.id,
+            from_user=types.User._parse(client, users.get(utils.get_raw_peer_id(message.from_id))),
+            chat=types.Chat._parse(client, message, users, chats, is_chat=True),
+            receiver=types.User._parse(client, users.get(message.receiver_id)),
+            date=utils.timestamp_to_datetime(message.date),
+            outgoing=message.out,
+            message_thread_id=message.top_msg_id,
+            text=Str(message.message).init(entities) or None if media_type is None else None,
+            caption=Str(message.message).init(entities) or None if media_type is not None else None,
+            entities=entities or None if media_type is None else None,
+            caption_entities=entities or None if media_type is not None else None,
+            media=media_type,
+            photo=photo,
+            animation=animation,
+            audio=audio,
+            document=document,
+            sticker=sticker,
+            video=video,
+            video_note=video_note,
+            voice=voice,
+            has_media_spoiler=has_media_spoiler,
+            reply_markup=reply_markup,
+            reply_to_message_id=getattr(message.reply_to, "reply_to_msg_id", None) or getattr(message.reply_to, "id", None),
+            raw=message,
+            client=client,
+        )
+
+    @staticmethod
+    def _parse_deleted(
+        client: "pyrogram.Client",
+        update: "raw.types.UpdateDeleteEphemeralMessages",
+        users: Dict[int, "raw.base.User"],
+        chats: Dict[int, "raw.base.Chat"],
+    ) -> List["EphemeralMessage"]:
+        peer = getattr(update, "peer", None)
+        chat = None
+
+        if peer:
+            chat_id = utils.get_raw_peer_id(peer)
+
+            if isinstance(peer, raw.types.PeerUser):
+                chat = types.Chat._parse_user_chat(client, users.get(chat_id))
+            elif isinstance(peer, raw.types.PeerChat):
+                chat = types.Chat._parse_chat_chat(client, chats.get(chat_id))
+            else:
+                chat = types.Chat._parse_channel_chat(client, chats.get(chat_id))
+
+        return types.List(
+            EphemeralMessage(id=message_id, chat=chat, client=client)
+            for message_id in update.ids
+        )
+
+    @property
+    def content(self) -> Str:
+        return self.text or self.caption or Str("").init([])
+
+    async def reply(
+        self,
+        text: str = "",
+        entities: List["types.MessageEntity"] = None,
+        media: "types.InputMedia" = None,
+        reply_markup: Union[
+            "types.InlineKeyboardMarkup",
+            "types.ReplyKeyboardMarkup",
+            "types.ReplyKeyboardRemove",
+            "types.ForceReply",
+        ] = None,
+    ) -> "EphemeralMessage":
+        """Bound method *reply* of :obj:`~pyrogram.types.EphemeralMessage`.
+
+        Use this method as a shortcut for:
+
+        .. code-block:: python
+
+            await client.send_ephemeral_message(
+                chat_id=message.chat.id,
+                receiver_id=message.receiver.id,
+                text="hello",
+                reply_to_message_id=message.id
+            )
+
+        Example:
+            .. code-block:: python
+
+                await message.reply("hello")
+
+        Parameters:
+            text (``str``, *optional*):
+                Text of the message to be sent.
+
+            entities (List of :obj:`~pyrogram.types.MessageEntity`, *optional*):
+                List of special entities that appear in the message text, which can be specified
+                instead of *parse_mode*.
+
+            media (:obj:`~pyrogram.types.InputMedia`, *optional*):
+                Media to attach to the message.
+
+            reply_markup (:obj:`~pyrogram.types.InlineKeyboardMarkup`, *optional*):
+                Additional interface options.
+
+        Returns:
+            :obj:`~pyrogram.types.EphemeralMessage`: On success, the sent ephemeral message is returned.
+        """
+        return await self._client.send_ephemeral_message(
+            chat_id=self.chat.id,
+            receiver_id=self.receiver.id,
+            text=text,
+            entities=entities,
+            media=media,
+            reply_markup=reply_markup,
+            reply_to_message_id=self.id,
+        )
+
+    async def edit_text(
+        self,
+        text: str,
+        entities: List["types.MessageEntity"] = None,
+        reply_markup: "types.InlineKeyboardMarkup" = None,
+    ) -> "EphemeralMessage":
+        """Bound method *edit_text* of :obj:`~pyrogram.types.EphemeralMessage`.
+
+        Use this method as a shortcut for:
+
+        .. code-block:: python
+
+            await client.edit_ephemeral_message_text(
+                chat_id=message.chat.id,
+                receiver_id=message.receiver.id,
+                message_id=message.id,
+                text="new text"
+            )
+
+        Example:
+            .. code-block:: python
+
+                await message.edit_text("new text")
+
+        Parameters:
+            text (``str``):
+                New text of the message.
+
+            entities (List of :obj:`~pyrogram.types.MessageEntity`, *optional*):
+                List of special entities that appear in the message text, which can be specified
+                instead of *parse_mode*.
+
+            reply_markup (:obj:`~pyrogram.types.InlineKeyboardMarkup`, *optional*):
+                An InlineKeyboardMarkup object.
+
+        Returns:
+            :obj:`~pyrogram.types.EphemeralMessage`: On success, the edited message is returned.
+        """
+        return await self._client.edit_ephemeral_message_text(
+            chat_id=self.chat.id,
+            receiver_id=self.receiver.id,
+            message_id=self.id,
+            text=text,
+            entities=entities,
+            reply_markup=reply_markup,
+        )
+
+    async def edit_media(
+        self,
+        media: "types.InputMedia",
+        reply_markup: "types.InlineKeyboardMarkup" = None,
+    ) -> "EphemeralMessage":
+        """Bound method *edit_media* of :obj:`~pyrogram.types.EphemeralMessage`.
+
+        Use this method as a shortcut for:
+
+        .. code-block:: python
+
+            await client.edit_ephemeral_message_media(
+                chat_id=message.chat.id,
+                receiver_id=message.receiver.id,
+                message_id=message.id,
+                media=media
+            )
+
+        Parameters:
+            media (:obj:`~pyrogram.types.InputMedia`):
+                One of the InputMedia objects describing an animation, audio, document, photo or video.
+
+            reply_markup (:obj:`~pyrogram.types.InlineKeyboardMarkup`, *optional*):
+                An InlineKeyboardMarkup object.
+
+        Returns:
+            :obj:`~pyrogram.types.EphemeralMessage`: On success, the edited message is returned.
+        """
+        return await self._client.edit_ephemeral_message_media(
+            chat_id=self.chat.id,
+            receiver_id=self.receiver.id,
+            message_id=self.id,
+            media=media,
+            reply_markup=reply_markup,
+        )
+
+    async def delete(self) -> bool:
+        """Bound method *delete* of :obj:`~pyrogram.types.EphemeralMessage`.
+
+        Use this method as a shortcut for:
+
+        .. code-block:: python
+
+            await client.delete_ephemeral_messages(
+                chat_id=message.chat.id,
+                receiver_id=message.receiver.id,
+                message_ids=message.id
+            )
+
+        Example:
+            .. code-block:: python
+
+                await message.delete()
+
+        Returns:
+            ``bool``: True on success.
+        """
+        return await self._client.delete_ephemeral_messages(
+            chat_id=self.chat.id,
+            receiver_id=self.receiver.id,
+            message_ids=self.id,
+        )
+
+    async def report(self, option: bytes, message: str = "") -> "raw.base.ReportResult":
+        """Bound method *report* of :obj:`~pyrogram.types.EphemeralMessage`.
+
+        Use this method as a shortcut for:
+
+        .. code-block:: python
+
+            await client.report_ephemeral_message(
+                chat_id=message.chat.id,
+                message_id=message.id,
+                option=option
+            )
+
+        Parameters:
+            option (``bytes``):
+                The option chosen from a previously received :obj:`~pyrogram.raw.base.ReportResult`.
+
+            message (``str``, *optional*):
+                An optional free-form message describing the report.
+
+        Returns:
+            :obj:`~pyrogram.raw.base.ReportResult`
+        """
+        return await self._client.report_ephemeral_message(
+            chat_id=self.chat.id,
+            message_id=self.id,
+            option=option,
+            message=message,
+        )

--- a/pyrogram/types/messages_and_media/reply_parameters.py
+++ b/pyrogram/types/messages_and_media/reply_parameters.py
@@ -60,6 +60,12 @@ class ReplyParameters(Object):
 
         poll_option_id (``str``, *optional*):
             Persistent identifier of the specific poll option to be replied to.
+
+        ephemeral_message_id (``int``, *optional*):
+            Identifier of the incoming ephemeral message that will be replied to in the current
+            chat. A reply to an ephemeral message must itself be an ephemeral message. An ephemeral
+            message may only be replied to within 15 seconds of being sent. Mutually exclusive with
+            *message_id*.
     """
 
     def __init__(
@@ -74,6 +80,7 @@ class ReplyParameters(Object):
         quote_position: Optional[int] = None,
         checklist_task_id: Optional[int] = None,
         poll_option_id: Optional[str] = None,
+        ephemeral_message_id: Optional[int] = None,
     ):
         super().__init__()
 
@@ -86,3 +93,4 @@ class ReplyParameters(Object):
         self.quote_position = quote_position
         self.checklist_task_id = checklist_task_id
         self.poll_option_id = poll_option_id
+        self.ephemeral_message_id = ephemeral_message_id

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -451,6 +451,11 @@ async def get_reply_to(
                 story_id=reply_parameters.story_id
             )
 
+        if reply_parameters.ephemeral_message_id:
+            return raw.types.InputReplyToEphemeralMessage(
+                id=reply_parameters.ephemeral_message_id
+            )
+
         if reply_parameters.message_id:
             message = None
             entities = None

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -293,6 +293,20 @@ def parse_deleted_messages(client, update, users, chats) -> List["types.Message"
     return types.List(parsed_messages)
 
 
+async def parse_ephemeral_message(
+    client: "pyrogram.Client",
+    updates: "raw.base.Updates"
+) -> Optional["types.EphemeralMessage"]:
+    users = {i.id: i for i in getattr(updates, "users", [])}
+    chats = {i.id: i for i in getattr(updates, "chats", [])}
+
+    for u in getattr(updates, "updates", []):
+        if isinstance(u, (raw.types.UpdateNewEphemeralMessage, raw.types.UpdateEditEphemeralMessage)):
+            return await types.EphemeralMessage._parse(client, u.message, users, chats)
+
+    return None
+
+
 def pack_inline_message_id(msg_id: "raw.base.InputBotInlineMessageID"):
     if isinstance(msg_id, raw.types.InputBotInlineMessageID):
         inline_message_id_packed = struct.pack(
@@ -406,6 +420,21 @@ def get_peer_type(peer_id: int) -> str:
         return "user"
 
     raise ValueError(f"Peer id invalid: {peer_id}")
+
+
+async def resolve_receiver(
+    client: "pyrogram.Client",
+    receiver_id: Union[int, str]
+) -> "raw.base.InputUser":
+    """Resolve a receiver_id into an InputUser, for use with the ephemeral message API."""
+    peer = await client.resolve_peer(receiver_id)
+
+    if isinstance(peer, raw.types.InputPeerUser):
+        return raw.types.InputUser(user_id=peer.user_id, access_hash=peer.access_hash)
+    elif isinstance(peer, raw.types.InputPeerSelf):
+        return raw.types.InputUserSelf()
+
+    raise ValueError(f"The receiver_id \"{receiver_id}\" does not belong to a user")
 
 
 async def get_reply_to(


### PR DESCRIPTION
## Add support for Ephemeral Messages (Layer 228)

Adds support for Telegram's new ephemeral messages.

**Added:**
- `types.EphemeralMessage`, `types.EphemeralCallbackQuery`
- Client methods: `send_ephemeral_message`, `edit_ephemeral_message_text`, `edit_ephemeral_message_media`, `delete_ephemeral_messages`, `report_ephemeral_message`, `request_ephemeral_callback_answer`
- Handlers/decorators: `on_ephemeral_message`, `on_edited_ephemeral_message`, `on_deleted_ephemeral_messages`, `on_ephemeral_callback_query`
- Dispatcher support for `UpdateNewEphemeralMessage`, `UpdateEditEphemeralMessage`, `UpdateDeleteEphemeralMessages`, `UpdateEphemeralBotCallbackQuery`
- `utils.resolve_receiver`, `utils.parse_ephemeral_message` helpers