### PR TITLE
fix(download): resolve relative download paths against `workdir`

### DIFF
--- a/pyrogram/methods/messages/download_media.py
+++ b/pyrogram/methods/messages/download_media.py
@@ -300,7 +300,7 @@ class DownloadMedia:
             directory, file_name = os.path.split(file_name)
             file_name = file_name or thumb.name
 
-            if not os.path.isabs(file_name):
+            if not os.path.isabs(directory):
                 directory = self.workdir / (directory or DEFAULT_DOWNLOAD_DIR)
 
             os.makedirs(directory, exist_ok=True) if not in_memory else None
@@ -333,7 +333,7 @@ class DownloadMedia:
         directory, file_name = os.path.split(file_name)
         file_name = file_name or media_file_name or ""
 
-        if not os.path.isabs(file_name):
+        if not os.path.isabs(directory):
             directory = self.workdir / (directory or DEFAULT_DOWNLOAD_DIR)
 
         if not file_name:

--- a/pyrogram/methods/messages/download_media.py
+++ b/pyrogram/methods/messages/download_media.py
@@ -301,7 +301,7 @@ class DownloadMedia:
             file_name = file_name or thumb.name
 
             if not os.path.isabs(file_name):
-                directory = self.PARENT_DIR / (directory or DEFAULT_DOWNLOAD_DIR)
+                directory = self.workdir / (directory or DEFAULT_DOWNLOAD_DIR)
 
             os.makedirs(directory, exist_ok=True) if not in_memory else None
 
@@ -334,7 +334,7 @@ class DownloadMedia:
         file_name = file_name or media_file_name or ""
 
         if not os.path.isabs(file_name):
-            directory = self.PARENT_DIR / (directory or DEFAULT_DOWNLOAD_DIR)
+            directory = self.workdir / (directory or DEFAULT_DOWNLOAD_DIR)
 
         if not file_name:
             guessed_extension = self.guess_extension(mime_type)


### PR DESCRIPTION
Fixes #338.

## What

Relative download paths now resolve against `workdir` instead of `Client.PARENT_DIR` (the directory of the entry-point script), which is what the `file_name` docstring has always promised:

> By default, all files are downloaded in the *downloads* folder in **your working directory**.

Both call sites are covered — the one that writes stripped thumbnails inline, and the one that feeds `handle_download()` for every other kind of media.

## Why

`PARENT_DIR` follows the code, so a client deployed on a read-only path cannot download anything at all, no matter what `workdir` points at — `handle_download()` dies in `os.makedirs()` on a directory next to the sources. There is no parameter to move the target either; only an absolute `file_name` on every single call gets around it. #338 has the full reproduction.

## Compatibility

Not a breaking change. `WORKDIR = PARENT_DIR`, so a client that does not pass `workdir` resolves downloads exactly where it does today. Behaviour changes only for clients that pass `workdir` explicitly, and for those it becomes what the documentation already describes.

If tying downloads to `workdir` feels too broad, I am happy to redo this as a dedicated `download_dir` parameter defaulting to `workdir` — say the word.

## Second commit — drop it if you disagree

`os.path.isabs()` was being applied to `file_name` *after* `os.path.split()` had already reduced it to a bare basename, so it was testing something that can never be absolute and the branch effectively always ran. Absolute paths kept working by accident: `Path("/a") / "/b" == Path("/b")` meant an absolute `directory` swallowed the prefix anyway. Testing `directory` states the actual intent.

Same resulting path in every ordinary case. The one behavioural difference is when Telegram itself supplies an absolute file name — previously `directory` stayed relative and got resolved against the CWD, now it lands under `workdir` like everything else. `directory` is only ever consumed by `os.makedirs()`, `os.path.join()` and `os.path.abspath()`, so it staying a `str` in the absolute branch changes nothing.

It is a separate concern from the bug, so it is a separate commit — drop it and I will rebase if you would rather keep this PR minimal.

## Testing

Against a real account, code in one directory, CWD in another, `workdir` in a third:

| `file_name` | before | after |
| --- | --- | --- |
| `"downloads/"` | `<code dir>/downloads/photo_….jpg` | `<workdir>/downloads/photo_….jpg` |
| `"downloads/nested/"` | `<code dir>/downloads/nested/…` | `<workdir>/downloads/nested/…` |
| absolute path | honoured | honoured |

No `workdir` passed: identical paths before and after. Nothing is created next to the sources any more. Both the stripped-thumbnail branch and the regular `handle_download()` path were exercised.
