### PR TITLE
fix(typing): overload the shape-dependent methods and stop hiding the `None`s

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -33,7 +33,7 @@ from importlib import import_module
 from io import BytesIO, StringIO
 from mimetypes import MimeTypes
 from pathlib import Path
-from typing import AsyncGenerator, Callable, List, Optional, Type, Union
+from typing import AsyncIterator, Callable, List, Optional, Type, Union
 
 import pyrogram
 from pyrogram import __license__, __version__, enums, raw, utils
@@ -1120,7 +1120,7 @@ class Client(Methods):
         offset: int = 0,
         progress: Optional[Callable] = None,
         progress_args: tuple = ()
-    ) -> AsyncGenerator[bytes, None]:
+    ) -> AsyncIterator[bytes]:
         async with self.get_file_semaphore:
             file_type = file_id.file_type
 

--- a/pyrogram/methods/account/add_profile_audio.py
+++ b/pyrogram/methods/account/add_profile_audio.py
@@ -36,7 +36,7 @@ class AddProfileAudio:
         file_name: Optional[str] = None,
         progress: Optional[Callable] = None,
         progress_args: Optional[tuple] = (),
-    ):
+    ) -> Optional[bool]:
         """Adds an audio file to the beginning of the profile audio files of the current user.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/advanced/resolve_peer.py
+++ b/pyrogram/methods/advanced/resolve_peer.py
@@ -45,7 +45,8 @@ class ResolvePeer:
                 Can be a direct id (int), a username (str), a link (str) or a phone number (str).
 
         Returns:
-            :obj:`~pyrogram.raw.base.InputPeer`: On success, the resolved peer id is returned in form of an InputPeer object.
+            :obj:`~pyrogram.raw.base.InputPeer` | ``None``: On success, the resolved peer id is returned in
+            form of an InputPeer object, otherwise, in case *peer_id* is None, None is returned.
 
         Raises:
             KeyError: In case the peer doesn't exist in the internal database.

--- a/pyrogram/methods/advanced/save_file.py
+++ b/pyrogram/methods/advanced/save_file.py
@@ -89,9 +89,9 @@ class SaveFile:
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            ``InputFile`` | ``None``: On success, the uploaded file is returned in form of an InputFile
-            object. None is returned when *path* is None, when *file_id* is given so that a single
-            missing part is uploaded instead of the whole file, and when the upload fails.
+            ``InputFile`` | ``None``: On success, the uploaded file is returned in form of an InputFile object. In case
+            *path* is None, in case *file_id* is given so that a single missing part is uploaded instead of the whole
+            file, and in case the upload fails, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.

--- a/pyrogram/methods/advanced/save_file.py
+++ b/pyrogram/methods/advanced/save_file.py
@@ -43,7 +43,7 @@ class SaveFile:
         file_part: int = 0,
         progress: Optional[Callable] = None,
         progress_args: tuple = ()
-    ):
+    ) -> Optional[Union["raw.types.InputFile", "raw.types.InputFileBig"]]:
         """Upload a file onto Telegram servers, without actually sending the message to anyone.
         Useful whenever an InputFile type is required.
 
@@ -89,7 +89,9 @@ class SaveFile:
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            ``InputFile``: On success, the uploaded file is returned in form of an InputFile object.
+            ``InputFile`` | ``None``: On success, the uploaded file is returned in form of an InputFile
+            object. None is returned when *path* is None, when *file_id* is given so that a single
+            missing part is uploaded instead of the whole file, and when the upload fails.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -177,7 +179,7 @@ class SaveFile:
                     await queue.put(rpc)
 
                     if is_missing_part:
-                        return
+                        return None
 
                     if not is_big and not is_missing_part:
                         md5_sum.update(chunk)
@@ -223,3 +225,8 @@ class SaveFile:
 
                 if isinstance(path, (str, PurePath)):
                     fp.close()
+
+            # NOTE: The `except Exception` branch above logs the failure and swallows it, so the
+            #       upload can end without a file. Saying so explicitly keeps that outcome
+            #       visible instead of leaving it to fall off the end of the method.
+            return None

--- a/pyrogram/methods/advanced/save_file.py
+++ b/pyrogram/methods/advanced/save_file.py
@@ -226,7 +226,6 @@ class SaveFile:
                 if isinstance(path, (str, PurePath)):
                     fp.close()
 
-            # NOTE: The `except Exception` branch above logs the failure and swallows it, so the
-            #       upload can end without a file. Saying so explicitly keeps that outcome
-            #       visible instead of leaving it to fall off the end of the method.
+            # NOTE: The `except Exception` branch above swallows the failure, so the upload can end
+            #       without a file.
             return None

--- a/pyrogram/methods/auth/get_password_hint.py
+++ b/pyrogram/methods/auth/get_password_hint.py
@@ -17,6 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+from typing import Optional
 
 import pyrogram
 from pyrogram import raw
@@ -27,12 +28,13 @@ log = logging.getLogger(__name__)
 class GetPasswordHint:
     async def get_password_hint(
         self: "pyrogram.Client",
-    ) -> str:
+    ) -> Optional[str]:
         """Get your Two-Step Verification password hint.
 
         .. include:: /_includes/usable-by/users.rst
 
         Returns:
-            ``str``: On success, the password hint as string is returned.
+            ``str`` | ``None``: On success, the password hint as string is returned, otherwise, in case
+            no hint was set, None is returned.
         """
         return (await self.invoke(raw.functions.account.GetPassword())).hint

--- a/pyrogram/methods/bots/edit_ephemeral_message_caption.py
+++ b/pyrogram/methods/bots/edit_ephemeral_message_caption.py
@@ -33,7 +33,7 @@ class EditEphemeralMessageCaption:
         parse_mode: Optional["enums.ParseMode"] = None,
         caption_entities: Optional[List["types.MessageEntity"]] = None,
         reply_markup: Optional["types.InlineKeyboardMarkup"] = None,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Use this method to edit the caption of an ephemeral message.
         Note that it is not guaranteed that the user will receive the message edit event, especially if they are offline.
 
@@ -63,7 +63,8 @@ class EditEphemeralMessageCaption:
                 An InlineKeyboardMarkup object.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the edited message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the edited message is returned, otherwise, in case
+            the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/bots/edit_ephemeral_message_media.py
+++ b/pyrogram/methods/bots/edit_ephemeral_message_media.py
@@ -30,7 +30,7 @@ class EditEphemeralMessageMedia:
         ephemeral_message_id: int,
         media: "types.InputMedia",
         reply_markup: Optional["types.InlineKeyboardMarkup"] = None,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Use this method to edit the media of an ephemeral message.
         Note that it is not guaranteed that the user will receive the message edit event, especially if they are offline.
 
@@ -57,7 +57,8 @@ class EditEphemeralMessageMedia:
                 Defaults to file's path basename.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the edited message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the edited message is returned,
+            otherwise, in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/bots/edit_ephemeral_message_reply_markup.py
+++ b/pyrogram/methods/bots/edit_ephemeral_message_reply_markup.py
@@ -29,7 +29,7 @@ class EditEphemeralMessageReplyMarkup:
         receiver_user_id: Union[int, str],
         ephemeral_message_id: int,
         reply_markup: Optional["types.InlineKeyboardMarkup"] = None,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Use this method to edit only the reply markup of an ephemeral message.
         Note that it is not guaranteed that the user will receive the message edit event, especially if they are offline.
 
@@ -49,7 +49,8 @@ class EditEphemeralMessageReplyMarkup:
                 An InlineKeyboardMarkup object.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the edited message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the edited message is returned,
+            otherwise, in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/bots/edit_ephemeral_message_text.py
+++ b/pyrogram/methods/bots/edit_ephemeral_message_text.py
@@ -33,7 +33,7 @@ class EditEphemeralMessageText:
         entities: Optional[List["types.MessageEntity"]] = None,
         link_preview_options: Optional["types.LinkPreviewOptions"] = None,
         reply_markup: Optional["types.InlineKeyboardMarkup"] = None,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Use this method to edit an ephemeral text message.
         Note that it is not guaranteed that the user will receive the message edit event, especially if they are offline.
 
@@ -66,7 +66,8 @@ class EditEphemeralMessageText:
                 An InlineKeyboardMarkup object.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the edited message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the edited message is returned,
+            otherwise, in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/bots/get_bot_default_privileges.py
+++ b/pyrogram/methods/bots/get_bot_default_privileges.py
@@ -38,7 +38,8 @@ class GetBotDefaultPrivileges:
                 for groups and supergroups will be returned.
 
         Returns:
-            ``bool``: On success, True is returned.
+            :obj:`~pyrogram.types.ChatAdministratorRights` | ``None``: On success, the default privileges of
+            the bot are returned, otherwise, in case the bot has no default privileges set, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/bots/send_game.py
+++ b/pyrogram/methods/bots/send_game.py
@@ -44,7 +44,7 @@ class SendGame:
 
         reply_to_message_id: Optional[int] = None,
         reply_to_chat_id: Optional[Union[int, str]] = None,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Send a game.
 
         .. include:: /_includes/usable-by/bots.rst
@@ -87,7 +87,8 @@ class SendGame:
                 If not empty, the first button must launch the game.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent game message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent game message is returned,
+            otherwise, in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/bots/send_inline_bot_result.py
+++ b/pyrogram/methods/bots/send_inline_bot_result.py
@@ -45,7 +45,7 @@ class SendInlineBotResult:
         parse_mode: Optional["enums.ParseMode"] = None,
         quote_entities: Optional[List["types.MessageEntity"]] = None,
         quote_offset: Optional[int] = None,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Send an inline bot result.
         Bot results can be retrieved using :meth:`~pyrogram.Client.get_inline_bot_results`
 
@@ -85,7 +85,8 @@ class SendInlineBotResult:
                 The number of Telegram Stars the user agreed to pay to send the messages.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent message is returned or False if no message was sent.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise,
+            in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/bots/send_invoice.py
+++ b/pyrogram/methods/bots/send_invoice.py
@@ -72,7 +72,7 @@ class SendInvoice:
         caption_entities: Optional[List["types.MessageEntity"]] = None,
 
         reply_to_message_id: Optional[int] = None,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Use this method to send invoices.
 
         .. include:: /_includes/usable-by/bots.rst
@@ -192,7 +192,8 @@ class SendInvoice:
                 List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent invoice message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent invoice message is returned,
+            otherwise, in case the server answered with no message, None is returned.
 
         """
         if reply_to_message_id is not None:

--- a/pyrogram/methods/chats/get_chat.py
+++ b/pyrogram/methods/chats/get_chat.py
@@ -48,9 +48,9 @@ class GetChat:
                 Defaults to True.
 
         Returns:
-            :obj:`~pyrogram.types.Chat` | ``None``: On success, if you've already joined the chat, a
-            chat object is returned, otherwise, a chat preview object is returned. None is returned when
-            the account can no longer see the chat and the server answers with an empty peer.
+            :obj:`~pyrogram.types.Chat` | ``None``: On success, if you've already joined the chat, a chat object is
+            returned, otherwise, a chat preview object is returned. In case the account can no longer see the chat and
+            the server answers with an empty peer, None is returned.
 
         Raises:
             ValueError: In case the chat invite link points to a chat you haven't joined yet.

--- a/pyrogram/methods/chats/get_chat.py
+++ b/pyrogram/methods/chats/get_chat.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from typing import Optional, Union
 
 import pyrogram
 from pyrogram import raw
@@ -29,7 +29,7 @@ class GetChat:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         force_full: bool = True
-    ) -> "types.Chat":
+    ) -> Optional["types.Chat"]:
         """Get up to date information about a chat.
 
         Information include current name of the user for one-on-one conversations, current username of a user, group or
@@ -48,8 +48,9 @@ class GetChat:
                 Defaults to True.
 
         Returns:
-            :obj:`~pyrogram.types.Chat`: On success, if you've already joined the chat, a chat object is returned,
-            otherwise, a chat preview object is returned.
+            :obj:`~pyrogram.types.Chat` | ``None``: On success, if you've already joined the chat, a
+            chat object is returned, otherwise, a chat preview object is returned. None is returned when
+            the account can no longer see the chat and the server answers with an empty peer.
 
         Raises:
             ValueError: In case the chat invite link points to a chat you haven't joined yet.

--- a/pyrogram/methods/chats/get_chat_event_log.py
+++ b/pyrogram/methods/chats/get_chat_event_log.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List, AsyncGenerator, Optional
+from typing import Union, List, AsyncIterator, Optional
 
 import pyrogram
 from pyrogram import raw
@@ -32,7 +32,7 @@ class GetChatEventLog:
         limit: int = 0,
         filters: Optional["types.ChatEventFilter"] = None,
         user_ids: Optional[List[Union[int, str]]] = None
-    ) -> AsyncGenerator["types.ChatEvent", None]:
+    ) -> AsyncIterator["types.ChatEvent"]:
         """Get the actions taken by chat members and administrators in the last 48h.
 
         Only available for supergroups and channels. Requires administrator rights.

--- a/pyrogram/methods/chats/get_chat_members.py
+++ b/pyrogram/methods/chats/get_chat_members.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Union, Optional, AsyncGenerator
+from typing import Union, Optional, AsyncIterator
 
 import pyrogram
 from pyrogram import raw, types, enums
@@ -64,7 +64,7 @@ class GetChatMembers:
         query: str = "",
         limit: int = 0,
         filter: "enums.ChatMembersFilter" = enums.ChatMembersFilter.SEARCH
-    ) -> AsyncGenerator["types.ChatMember", None]:
+    ) -> AsyncIterator["types.ChatMember"]:
         """Get the members list of a chat.
 
         A chat can be either a basic group, a supergroup or a channel.

--- a/pyrogram/methods/chats/get_chat_members_count.py
+++ b/pyrogram/methods/chats/get_chat_members_count.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from typing import Optional, Union
 
 import pyrogram
 from pyrogram import raw
@@ -26,7 +26,7 @@ class GetChatMembersCount:
     async def get_chat_members_count(
         self: "pyrogram.Client",
         chat_id: Union[int, str]
-    ) -> int:
+    ) -> Optional[int]:
         """Get the number of members in a chat.
 
         .. include:: /_includes/usable-by/users-bots.rst
@@ -36,7 +36,8 @@ class GetChatMembersCount:
                 Unique identifier (int) or username (str) of the target chat.
 
         Returns:
-            ``int``: On success, the chat members count is returned.
+            ``int`` | ``None``: On success, the chat members count is returned, otherwise, in case the
+            server did not send the count, None is returned.
 
         Raises:
             ValueError: In case a chat id belongs to user.

--- a/pyrogram/methods/chats/get_dialogs.py
+++ b/pyrogram/methods/chats/get_dialogs.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncGenerator, Optional
+from typing import AsyncIterator, Optional
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -28,7 +28,7 @@ class GetDialogs:
         limit: int = 0,
         exclude_pinned: Optional[bool] = None,
         from_archive: Optional[bool] = None
-    ) -> AsyncGenerator["types.Dialog", None]:
+    ) -> AsyncIterator["types.Dialog"]:
         """Get a user's dialogs sequentially.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/chats/get_direct_messages_topics.py
+++ b/pyrogram/methods/chats/get_direct_messages_topics.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncGenerator, Optional, Union
+from typing import AsyncIterator, Optional, Union
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -28,7 +28,7 @@ class GetDirectMessagesTopics:
         chat_id: Union[int, str],
         limit: int = 0,
         exclude_pinned: Optional[bool] = None
-    ) -> AsyncGenerator["types.DirectMessagesTopic", None]:
+    ) -> AsyncIterator["types.DirectMessagesTopic"]:
         """Get one or more topic from a direct messages channel chat.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/chats/get_direct_messages_topics_by_id.py
+++ b/pyrogram/methods/chats/get_direct_messages_topics_by_id.py
@@ -59,8 +59,8 @@ class GetDirectMessagesTopicsByID:
 
         Returns:
             :obj:`~pyrogram.types.DirectMessagesTopic` | List of :obj:`~pyrogram.types.DirectMessagesTopic` | ``None``:
-            In case *topic_ids* was not a list, a single topic is returned, or None if it was not found, otherwise a
-            list of topics is returned.
+            In case *topic_ids* was not a list, a single topic is returned, otherwise a list of topics is returned. In
+            case *topic_ids* was not a list and the chat has no topic with that identifier, None is returned.
 
         Example:
             .. code-block:: python
@@ -89,4 +89,11 @@ class GetDirectMessagesTopicsByID:
         for i in r.dialogs:
             topics.append(types.DirectMessagesTopic._parse(client=self, topic=i, users=users, chats=chats))
 
+        # NOTE: A direct messages topic exists only once its peer has written to the chat, and the
+        #       server answers with the ones that do exist rather than with a placeholder for the
+        #       ones that do not. Asking for a peer without a topic is not an error, it is an empty
+        #       `dialogs` vector, so `topics` really can be empty here.
+        #
+        #       await app.get_direct_messages_topics_by_id(direct_messages_chat_id, user_id)   # -> None
+        #       await app.get_direct_messages_topics_by_id(direct_messages_chat_id, [user_id]) # -> []
         return topics if is_iterable else topics[0] if topics else None

--- a/pyrogram/methods/chats/get_direct_messages_topics_by_id.py
+++ b/pyrogram/methods/chats/get_direct_messages_topics_by_id.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Iterable, List, Union
+from typing import Iterable, List, Optional, Union, overload
 
 import pyrogram
 from pyrogram import raw, types
@@ -26,11 +26,25 @@ log = logging.getLogger(__name__)
 
 
 class GetDirectMessagesTopicsByID:
+    @overload
+    async def get_direct_messages_topics_by_id(
+        self: "pyrogram.Client",
+        chat_id: Union[int, str],
+        topic_ids: int
+    ) -> Optional["types.DirectMessagesTopic"]: ...
+
+    @overload
+    async def get_direct_messages_topics_by_id(
+        self: "pyrogram.Client",
+        chat_id: Union[int, str],
+        topic_ids: Iterable[int]
+    ) -> List["types.DirectMessagesTopic"]: ...
+
     async def get_direct_messages_topics_by_id(
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         topic_ids: Union[int, Iterable[int]]
-    ) -> Union["types.DirectMessagesTopic", List["types.DirectMessagesTopic"]]:
+    ) -> Optional[Union["types.DirectMessagesTopic", List["types.DirectMessagesTopic"]]]:
         """Get one or more direct message topic from a chat by using topic identifiers.
 
         .. include:: /_includes/usable-by/users.rst
@@ -44,8 +58,9 @@ class GetDirectMessagesTopicsByID:
                 topic themselves.
 
         Returns:
-            :obj:`~pyrogram.types.DirectMessagesTopic` | List of :obj:`~pyrogram.types.DirectMessagesTopic`: In case *topic_ids* was not
-            a list, a single topic is returned, otherwise a list of topics is returned.
+            :obj:`~pyrogram.types.DirectMessagesTopic` | List of :obj:`~pyrogram.types.DirectMessagesTopic` | ``None``:
+            In case *topic_ids* was not a list, a single topic is returned, or None if it was not found, otherwise a
+            list of topics is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/chats/get_direct_messages_topics_by_id.py
+++ b/pyrogram/methods/chats/get_direct_messages_topics_by_id.py
@@ -89,11 +89,8 @@ class GetDirectMessagesTopicsByID:
         for i in r.dialogs:
             topics.append(types.DirectMessagesTopic._parse(client=self, topic=i, users=users, chats=chats))
 
-        # NOTE: A direct messages topic exists only once its peer has written to the chat, and the
-        #       server answers with the ones that do exist rather than with a placeholder for the
-        #       ones that do not. Asking for a peer without a topic is not an error, it is an empty
-        #       `dialogs` vector, so `topics` really can be empty here.
+        # NOTE: A topic exists only once its peer has written to the chat, and asking for a peer
+        #       without one answers with an empty `dialogs` vector rather than an error:
         #
-        #       await app.get_direct_messages_topics_by_id(direct_messages_chat_id, user_id)   # -> None
-        #       await app.get_direct_messages_topics_by_id(direct_messages_chat_id, [user_id]) # -> []
+        #       await app.get_direct_messages_topics_by_id(chat_id, user_id)  # -> None
         return topics if is_iterable else topics[0] if topics else None

--- a/pyrogram/methods/chats/get_forum_topics.py
+++ b/pyrogram/methods/chats/get_forum_topics.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncGenerator, Union
+from typing import AsyncIterator, Union
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -27,7 +27,7 @@ class GetForumTopics:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         limit: int = 0
-    ) -> AsyncGenerator["types.ForumTopic", None]:
+    ) -> AsyncIterator["types.ForumTopic"]:
         """Get one or more topic from a chat.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/chats/get_forum_topics_by_id.py
+++ b/pyrogram/methods/chats/get_forum_topics_by_id.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Iterable, List, Optional, Union, overload
+from typing import Iterable, List, Union, overload
 
 import pyrogram
 from pyrogram import raw, types
@@ -31,7 +31,7 @@ class GetForumTopicsByID:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         topic_ids: int
-    ) -> Optional["types.ForumTopic"]: ...
+    ) -> "types.ForumTopic": ...
 
     @overload
     async def get_forum_topics_by_id(
@@ -44,7 +44,7 @@ class GetForumTopicsByID:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         topic_ids: Union[int, Iterable[int]]
-    ) -> Optional[Union["types.ForumTopic", List["types.ForumTopic"]]]:
+    ) -> Union["types.ForumTopic", List["types.ForumTopic"]]:
         """Get one or more topic from a chat by using topic identifiers.
 
         .. include:: /_includes/usable-by/users.rst
@@ -58,9 +58,8 @@ class GetForumTopicsByID:
                 topic themselves.
 
         Returns:
-            :obj:`~pyrogram.types.ForumTopic` | List of :obj:`~pyrogram.types.ForumTopic` | ``None``: In case
-            *topic_ids* was not a list, a single topic is returned, or None if it was not found, otherwise a list of
-            topics is returned.
+            :obj:`~pyrogram.types.ForumTopic` | List of :obj:`~pyrogram.types.ForumTopic`: In case *topic_ids* was not
+            a list, a single topic is returned, otherwise a list of topics is returned.
 
         Example:
             .. code-block:: python
@@ -92,4 +91,11 @@ class GetForumTopicsByID:
         for i in r.topics:
             topics.append(types.ForumTopic._parse(self, i, users=users, chats=chats))
 
-        return topics if is_iterable else topics[0] if topics else None
+        # NOTE: The server answers with one entry per requested id, never with fewer: a topic that
+        #       does not exist comes back as `forumTopicDeleted`, which `ForumTopic._parse()` turns
+        #       into a topic carrying `is_deleted`, and an id below 1 is refused with `TOPICS_EMPTY`
+        #       rather than skipped. So `topics` is never empty here.
+        #
+        #       await app.invoke(raw.functions.messages.GetForumTopicsByID(peer=peer, topics=[999999]))
+        #       # -> messages.ForumTopics(topics=[raw.types.ForumTopicDeleted(id=999999)], ...)
+        return topics if is_iterable else topics[0]

--- a/pyrogram/methods/chats/get_forum_topics_by_id.py
+++ b/pyrogram/methods/chats/get_forum_topics_by_id.py
@@ -91,9 +91,5 @@ class GetForumTopicsByID:
         for i in r.topics:
             topics.append(types.ForumTopic._parse(self, i, users=users, chats=chats))
 
-        # NOTE: One entry per requested id, never fewer: an id that does not exist comes back as
-        #       `forumTopicDeleted`, and one below 1 is refused with `TOPICS_EMPTY`:
-        #
-        #       GetForumTopicsByID(peer=peer, topics=[999999])
-        #       # -> messages.ForumTopics(topics=[raw.types.ForumTopicDeleted(id=999999)], ...)
+        # A topic that does not exist comes back as `forumTopicDeleted`, never as a missing entry.
         return topics if is_iterable else topics[0]

--- a/pyrogram/methods/chats/get_forum_topics_by_id.py
+++ b/pyrogram/methods/chats/get_forum_topics_by_id.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Iterable, List, Union
+from typing import Iterable, List, Optional, Union, overload
 
 import pyrogram
 from pyrogram import raw, types
@@ -26,11 +26,25 @@ log = logging.getLogger(__name__)
 
 
 class GetForumTopicsByID:
+    @overload
+    async def get_forum_topics_by_id(
+        self: "pyrogram.Client",
+        chat_id: Union[int, str],
+        topic_ids: int
+    ) -> Optional["types.ForumTopic"]: ...
+
+    @overload
+    async def get_forum_topics_by_id(
+        self: "pyrogram.Client",
+        chat_id: Union[int, str],
+        topic_ids: Iterable[int]
+    ) -> List["types.ForumTopic"]: ...
+
     async def get_forum_topics_by_id(
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         topic_ids: Union[int, Iterable[int]]
-    ) -> Union["types.ForumTopic", List["types.ForumTopic"]]:
+    ) -> Optional[Union["types.ForumTopic", List["types.ForumTopic"]]]:
         """Get one or more topic from a chat by using topic identifiers.
 
         .. include:: /_includes/usable-by/users.rst
@@ -44,8 +58,9 @@ class GetForumTopicsByID:
                 topic themselves.
 
         Returns:
-            :obj:`~pyrogram.types.ForumTopic` | List of :obj:`~pyrogram.types.ForumTopic`: In case *topic_ids* was not
-            a list, a single topic is returned, otherwise a list of topics is returned.
+            :obj:`~pyrogram.types.ForumTopic` | List of :obj:`~pyrogram.types.ForumTopic` | ``None``: In case
+            *topic_ids* was not a list, a single topic is returned, or None if it was not found, otherwise a list of
+            topics is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/chats/get_forum_topics_by_id.py
+++ b/pyrogram/methods/chats/get_forum_topics_by_id.py
@@ -91,11 +91,9 @@ class GetForumTopicsByID:
         for i in r.topics:
             topics.append(types.ForumTopic._parse(self, i, users=users, chats=chats))
 
-        # NOTE: The server answers with one entry per requested id, never with fewer: a topic that
-        #       does not exist comes back as `forumTopicDeleted`, which `ForumTopic._parse()` turns
-        #       into a topic carrying `is_deleted`, and an id below 1 is refused with `TOPICS_EMPTY`
-        #       rather than skipped. So `topics` is never empty here.
+        # NOTE: One entry per requested id, never fewer: an id that does not exist comes back as
+        #       `forumTopicDeleted`, and one below 1 is refused with `TOPICS_EMPTY`:
         #
-        #       await app.invoke(raw.functions.messages.GetForumTopicsByID(peer=peer, topics=[999999]))
+        #       GetForumTopicsByID(peer=peer, topics=[999999])
         #       # -> messages.ForumTopics(topics=[raw.types.ForumTopicDeleted(id=999999)], ...)
         return topics if is_iterable else topics[0]

--- a/pyrogram/methods/chats/get_personal_channels.py
+++ b/pyrogram/methods/chats/get_personal_channels.py
@@ -31,7 +31,8 @@ class GetPersonalChannels:
         .. include:: /_includes/usable-by/users.rst
 
         Returns:
-            List of :obj:`~pyrogram.types.Chat`: On success, a list of personal channels is returned.
+            List of :obj:`~pyrogram.types.Chat` | ``None``: On success, a list of personal channels is
+            returned, otherwise, in case there is no personal channel, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/chats/get_similar_channels.py
+++ b/pyrogram/methods/chats/get_similar_channels.py
@@ -37,7 +37,8 @@ class GetSimilarChannels:
                 Unique identifier (int) or username (str) of the target chat.
 
         Returns:
-            List of :obj:`~pyrogram.types.Chat`: On success, the list of channels is returned.
+            List of :obj:`~pyrogram.types.Chat` | ``None``: On success, the list of channels is returned,
+            otherwise, in case there is no similar channel, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/chats/get_top_chats.py
+++ b/pyrogram/methods/chats/get_top_chats.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncGenerator
+from typing import AsyncIterator
 
 import pyrogram
 from pyrogram import enums, raw, types, utils
@@ -27,7 +27,7 @@ class GetTopChats:
         self: "pyrogram.Client",
         category: "enums.TopChatCategory",
         limit: int = 0,
-    ) -> AsyncGenerator["types.Chat", None]:
+    ) -> AsyncIterator["types.Chat"]:
         """Returns a list of frequently used chats.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/chats/pin_chat_message.py
+++ b/pyrogram/methods/chats/pin_chat_message.py
@@ -57,7 +57,8 @@ class PinChatMessage:
                 Unique identifier of the business connection on behalf of which the message will be pinned.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the service message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the service message is returned, otherwise,
+            in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/chats/set_chat_photo.py
+++ b/pyrogram/methods/chats/set_chat_photo.py
@@ -34,7 +34,7 @@ class SetChatPhoto:
         photo: Optional[Union[str, BinaryIO]] = None,
         video: Optional[Union[str, BinaryIO]] = None,
         video_start_ts: Optional[float] = None,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Set a new chat photo or video (H.264/MPEG-4 AVC video, max 5 seconds).
 
         The ``photo`` and ``video`` arguments are mutually exclusive.
@@ -62,7 +62,8 @@ class SetChatPhoto:
                 The timestamp in seconds of the video frame to use as photo profile preview.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent service message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent service message is returned,
+            otherwise, in case the server answered with no message, None is returned.
 
         Raises:
             ValueError: if a chat_id belongs to user.

--- a/pyrogram/methods/chats/set_chat_title.py
+++ b/pyrogram/methods/chats/set_chat_title.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from typing import Optional, Union
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -25,7 +25,7 @@ from pyrogram import raw, types, utils
 class SetChatTitle:
     async def set_chat_title(
         self: "pyrogram.Client", chat_id: Union[int, str], title: str
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Change the title of a chat.
 
         Titles can't be changed for private chats.
@@ -41,7 +41,8 @@ class SetChatTitle:
                 New chat title, 1-255 characters.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent service message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent service message is returned,
+            otherwise, in case the server answered with no message, None is returned.
 
         Raises:
             ValueError: In case a chat id belongs to user.

--- a/pyrogram/methods/chats/set_chat_ttl.py
+++ b/pyrogram/methods/chats/set_chat_ttl.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from typing import Optional, Union
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -27,7 +27,7 @@ class SetChatTTL:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         ttl_seconds: int
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Set the time-to-live for the chat.
 
         .. include:: /_includes/usable-by/users.rst
@@ -41,7 +41,8 @@ class SetChatTTL:
                 Either 86000 for 1 day, 604800 for 1 week or 0 (zero) to disable it.
 
         Returns:
-            ``bool``: True on success.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent service message is returned,
+            otherwise, in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/contacts/delete_contacts.py
+++ b/pyrogram/methods/contacts/delete_contacts.py
@@ -16,13 +16,25 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Union
+from typing import List, Optional, Union, overload
 
 import pyrogram
 from pyrogram import raw, types
 
 
 class DeleteContacts:
+    @overload
+    async def delete_contacts(
+        self: "pyrogram.Client",
+        user_ids: Union[int, str]
+    ) -> Optional["types.User"]: ...
+
+    @overload
+    async def delete_contacts(
+        self: "pyrogram.Client",
+        user_ids: List[Union[int, str]]
+    ) -> Optional[List["types.User"]]: ...
+
     async def delete_contacts(
         self: "pyrogram.Client",
         user_ids: Union[int, str, List[Union[int, str]]]

--- a/pyrogram/methods/contacts/get_blocked_message_senders.py
+++ b/pyrogram/methods/contacts/get_blocked_message_senders.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncGenerator
+from typing import AsyncIterator
 
 import pyrogram
 from pyrogram import enums, raw, types, utils
@@ -28,7 +28,7 @@ class GetBlockedMessageSenders:
         block_list: "enums.BlockList" = enums.BlockList.MAIN,
         offset: int = 0,
         limit: int = 0,
-    ) -> AsyncGenerator["types.Chat", None]:
+    ) -> AsyncIterator["types.Chat"]:
         """Returns users and chats that were blocked by the current user.
 
         .. include:: /_includes/usable-by/users.rst
@@ -44,7 +44,7 @@ class GetBlockedMessageSenders:
                 The maximum number of users and chats to return.
 
         Returns:
-            AsyncGenerator of :obj:`~pyrogram.types.Chat`: An async generator that yields Chat objects.
+            ``Generator``: A generator yielding :obj:`~pyrogram.types.Chat` objects.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/invite_links/create_chat_invite_link.py
+++ b/pyrogram/methods/invite_links/create_chat_invite_link.py
@@ -32,7 +32,7 @@ class CreateChatInviteLink:
         expire_date: Optional[datetime] = None,
         member_limit: Optional[int] = None,
         creates_join_request: Optional[bool] = None
-    ) -> "types.ChatInviteLink":
+    ) -> Optional["types.ChatInviteLink"]:
         """Create an additional invite link for a chat.
 
         You must be an administrator in the chat for this to work and must have the appropriate admin rights.
@@ -63,7 +63,9 @@ class CreateChatInviteLink:
                 If True, member_limit can't be specified.
 
         Returns:
-            :obj:`~pyrogram.types.ChatInviteLink`: On success, the new invite link is returned.
+            :obj:`~pyrogram.types.ChatInviteLink` | ``None``: On success, the new invite link is
+            returned, otherwise, in case the chat only accepts join requests through its public link, None is
+            returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/invite_links/edit_chat_invite_link.py
+++ b/pyrogram/methods/invite_links/edit_chat_invite_link.py
@@ -33,7 +33,7 @@ class EditChatInviteLink:
         expire_date: Optional[datetime] = None,
         member_limit: Optional[int] = None,
         creates_join_request: Optional[bool] = None
-    ) -> "types.ChatInviteLink":
+    ) -> Optional["types.ChatInviteLink"]:
         """Edit a non-primary invite link.
 
         You must be an administrator in the chat for this to work and must have the appropriate admin rights.
@@ -65,7 +65,9 @@ class EditChatInviteLink:
                 If True, member_limit can't be specified.
 
         Returns:
-            :obj:`~pyrogram.types.ChatInviteLink`: On success, the new invite link is returned
+            :obj:`~pyrogram.types.ChatInviteLink` | ``None``: On success, the new invite link is
+            returned, otherwise, in case the chat only accepts join requests through its public link, None is
+            returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/invite_links/get_chat_admin_invite_links.py
+++ b/pyrogram/methods/invite_links/get_chat_admin_invite_links.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, Optional, AsyncGenerator
+from typing import Union, Optional, AsyncIterator
 
 import pyrogram
 from pyrogram import raw
@@ -30,7 +30,7 @@ class GetChatAdminInviteLinks:
         admin_id: Union[int, str],
         revoked: bool = False,
         limit: int = 0,
-    ) -> AsyncGenerator["types.ChatInviteLink", None]:
+    ) -> AsyncIterator["types.ChatInviteLink"]:
         """Get the invite links created by an administrator in a chat.
 
         .. note::

--- a/pyrogram/methods/invite_links/get_chat_invite_link.py
+++ b/pyrogram/methods/invite_links/get_chat_invite_link.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from typing import Optional, Union
 
 import pyrogram
 from pyrogram import raw, types
@@ -27,7 +27,7 @@ class GetChatInviteLink:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         invite_link: str,
-    ) -> "types.ChatInviteLink":
+    ) -> Optional["types.ChatInviteLink"]:
         """Get detailed information about a chat invite link.
 
         .. include:: /_includes/usable-by/users.rst
@@ -41,7 +41,9 @@ class GetChatInviteLink:
                 The invite link.
 
         Returns:
-            :obj:`~pyrogram.types.ChatInviteLink`: On success, the invite link is returned.
+            :obj:`~pyrogram.types.ChatInviteLink` | ``None``: On success, the invite link is returned,
+            otherwise, in case the chat only accepts join requests through its public link, None is
+            returned.
         """
         r = await self.invoke(
             raw.functions.messages.GetExportedChatInvite(

--- a/pyrogram/methods/invite_links/get_chat_invite_link_joiners.py
+++ b/pyrogram/methods/invite_links/get_chat_invite_link_joiners.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, Optional, AsyncGenerator
+from typing import Union, Optional, AsyncIterator
 
 import pyrogram
 from pyrogram import raw
@@ -29,7 +29,7 @@ class GetChatInviteLinkJoiners:
         chat_id: Union[int, str],
         invite_link: str,
         limit: int = 0
-    ) -> AsyncGenerator["types.ChatJoiner", None]:
+    ) -> AsyncIterator["types.ChatJoiner"]:
         """Get the members who joined the chat with the invite link.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/invite_links/get_chat_join_requests.py
+++ b/pyrogram/methods/invite_links/get_chat_join_requests.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, Optional, AsyncGenerator
+from typing import Union, Optional, AsyncIterator
 
 import pyrogram
 from pyrogram import raw
@@ -29,7 +29,7 @@ class GetChatJoinRequests:
         chat_id: Union[int, str],
         limit: int = 0,
         query: str = ""
-    ) -> AsyncGenerator["types.ChatJoiner", None]:
+    ) -> AsyncIterator["types.ChatJoiner"]:
         """Get the pending join requests of a chat.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/invite_links/revoke_chat_invite_link.py
+++ b/pyrogram/methods/invite_links/revoke_chat_invite_link.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from typing import Optional, Union
 
 import pyrogram
 from pyrogram import raw
@@ -28,7 +28,7 @@ class RevokeChatInviteLink:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         invite_link: str,
-    ) -> "types.ChatInviteLink":
+    ) -> Optional["types.ChatInviteLink"]:
         """Revoke a previously created invite link.
 
         If the primary link is revoked, a new link is automatically generated.
@@ -46,7 +46,9 @@ class RevokeChatInviteLink:
                The invite link to revoke.
 
         Returns:
-            :obj:`~pyrogram.types.ChatInviteLink`: On success, the invite link object is returned.
+            :obj:`~pyrogram.types.ChatInviteLink` | ``None``: On success, the invite link object is
+            returned, otherwise, in case the chat only accepts join requests through its public link, None is
+            returned.
         """
 
         r = await self.invoke(

--- a/pyrogram/methods/messages/copy_message.py
+++ b/pyrogram/methods/messages/copy_message.py
@@ -59,7 +59,7 @@ class CopyMessage:
         reply_to_message_id: Optional[int] = None,
         quote_text: Optional[str] = None,
         quote_entities: Optional[List["types.MessageEntity"]] = None,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Copy messages of any kind.
 
         The method is analogous to the method :meth:`~Client.forward_messages`, but the copied message doesn't have a
@@ -132,7 +132,8 @@ class CopyMessage:
                 Pass None to remove the reply markup.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the copied message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the copied message is returned,
+            otherwise, in case no message was sent, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/messages/download_media.py
+++ b/pyrogram/methods/messages/download_media.py
@@ -236,11 +236,11 @@ class DownloadMedia:
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            ``str`` | ``None`` | ``BinaryIO`` | ``List[str]`` | ``List[BinaryIO]``: On success, the absolute path of the downloaded file is returned,
-            otherwise, in case the download failed or was deliberately stopped with
+            ``str`` | ``BinaryIO`` | ``List[str]`` | ``List[BinaryIO]`` | ``None``: On success, the absolute path of the
+            downloaded file is returned. In case ``in_memory=True``, a binary file-like object with its attribute
+            ".name" set is returned. If the message contains multiple media (purchased paid media), a list of paths or
+            binary file-like objects is returned. In case the download failed or was deliberately stopped with
             :meth:`~pyrogram.Client.stop_transmission`, None is returned.
-            Otherwise, in case ``in_memory=True``, a binary file-like object with its attribute ".name" set is returned.
-            If the message contains multiple media (purchased paid media), a list of paths or binary file-like objects is returned.
 
         Raises:
             ValueError: if the message doesn't contain any downloadable media

--- a/pyrogram/methods/messages/download_media.py
+++ b/pyrogram/methods/messages/download_media.py
@@ -28,6 +28,74 @@ DEFAULT_DOWNLOAD_DIR = "downloads/"
 
 
 class DownloadMedia:
+    # NOTE: The overloads mirror the implementation signature, keywords and defaults
+    #       included, so that every call the implementation accepts also resolves for a
+    #       type checker. They are ordered from the most specific call to the least: a
+    #       call that passes neither `in_memory` nor `block` matches the first one.
+    #
+    #       The last one is the catch-all for arguments a checker cannot pin to a
+    #       literal, and it has to be last. Without it, a call that passes a plain
+    #       `bool` variable lands on the `block=False` overload — an omitted argument is
+    #       not checked against its default — and is told it returns `None` while at
+    #       runtime it blocks and returns a path:
+    #
+    #           flag: bool = ...
+    #           reveal_type(await app.download_media(message, in_memory=flag))
+    #           # -> Revealed type is "None"
+    @overload
+    async def download_media(
+        self: "pyrogram.Client",
+        message: Union[
+            str,
+            "types.Message",
+            "types.Story",
+            "types.Audio",
+            "types.Document",
+            "types.Photo",
+            "types.Sticker",
+            "types.Animation",
+            "types.Video",
+            "types.Voice",
+            "types.VideoNote",
+            "types.PaidMediaInfo",
+            "types.Thumbnail",
+            "types.StrippedThumbnail",
+            "types.PaidMediaPreview",
+        ],
+        file_name: str = DEFAULT_DOWNLOAD_DIR,
+        in_memory: Literal[False] = False,
+        block: Literal[True] = True,
+        progress: Optional[Callable] = None,
+        progress_args: tuple = (),
+    ) -> Union[str, List[str]]: ...
+
+    @overload
+    async def download_media(
+        self: "pyrogram.Client",
+        message: Union[
+            str,
+            "types.Message",
+            "types.Story",
+            "types.Audio",
+            "types.Document",
+            "types.Photo",
+            "types.Sticker",
+            "types.Animation",
+            "types.Video",
+            "types.Voice",
+            "types.VideoNote",
+            "types.PaidMediaInfo",
+            "types.Thumbnail",
+            "types.StrippedThumbnail",
+            "types.PaidMediaPreview",
+        ],
+        file_name: str = DEFAULT_DOWNLOAD_DIR,
+        in_memory: Literal[True] = True,
+        block: Literal[True] = True,
+        progress: Optional[Callable] = None,
+        progress_args: tuple = (),
+    ) -> Union[BinaryIO, List[BinaryIO]]: ...
+
     @overload
     async def download_media(
         self: "pyrogram.Client",
@@ -76,13 +144,12 @@ class DownloadMedia:
             "types.StrippedThumbnail",
             "types.PaidMediaPreview",
         ],
-        file_name: str = DEFAULT_DOWNLOAD_DIR,
-        *,
-        in_memory: Literal[True],
-        block: bool = True,
+        file_name: str,
+        in_memory: bool,
+        block: Literal[False],
         progress: Optional[Callable] = None,
         progress_args: tuple = (),
-    ) -> Union[BinaryIO, List[BinaryIO]]: ...
+    ) -> None: ...
 
     @overload
     async def download_media(
@@ -105,13 +172,11 @@ class DownloadMedia:
             "types.PaidMediaPreview",
         ],
         file_name: str = DEFAULT_DOWNLOAD_DIR,
-        *,
-        in_memory: Literal[False],
+        in_memory: bool = False,
         block: bool = True,
         progress: Optional[Callable] = None,
         progress_args: tuple = (),
-    ) -> Union[str, List[str]]:
-        ...
+    ) -> Union[str, BinaryIO, List[str], List[BinaryIO], None]: ...
 
     async def download_media(
         self: "pyrogram.Client",

--- a/pyrogram/methods/messages/download_media.py
+++ b/pyrogram/methods/messages/download_media.py
@@ -28,30 +28,6 @@ DEFAULT_DOWNLOAD_DIR = "downloads/"
 
 
 class DownloadMedia:
-    # NOTE: The overloads mirror the implementation signature, keywords and defaults
-    #       included, so that every call the implementation accepts also resolves for a
-    #       type checker. They are ordered from the most specific call to the least: a
-    #       call that passes neither `in_memory` nor `block` matches the first one.
-    #
-    #       The last one is the catch-all for arguments a checker cannot pin to a
-    #       literal, and it has to be last. Without it, a call that passes a plain
-    #       `bool` variable lands on the `block=False` overload — an omitted argument is
-    #       not checked against its default — and is told it returns `None` while at
-    #       runtime it blocks and returns a path:
-    #
-    #           flag: bool = ...
-    #           reveal_type(await app.download_media(message, in_memory=flag))
-    #           # -> Revealed type is "None"
-    #
-    #       The two blocking overloads admit `None` because a stopped transfer resolves
-    #       to it: `handle_download()` returns `None` on `StopTransmission` instead of
-    #       re-raising, and this method hands that result straight back.
-    #
-    #           def progress(current, total, client):
-    #               client.stop_transmission()
-    #
-    #           await app.download_media(message, progress=progress, progress_args=(app,))
-    #           # -> None
     @overload
     async def download_media(
         self: "pyrogram.Client",

--- a/pyrogram/methods/messages/download_media.py
+++ b/pyrogram/methods/messages/download_media.py
@@ -42,6 +42,16 @@ class DownloadMedia:
     #           flag: bool = ...
     #           reveal_type(await app.download_media(message, in_memory=flag))
     #           # -> Revealed type is "None"
+    #
+    #       The two blocking overloads admit `None` because a stopped transfer resolves
+    #       to it: `handle_download()` returns `None` on `StopTransmission` instead of
+    #       re-raising, and this method hands that result straight back.
+    #
+    #           def progress(current, total, client):
+    #               client.stop_transmission()
+    #
+    #           await app.download_media(message, progress=progress, progress_args=(app,))
+    #           # -> None
     @overload
     async def download_media(
         self: "pyrogram.Client",
@@ -67,7 +77,7 @@ class DownloadMedia:
         block: Literal[True] = True,
         progress: Optional[Callable] = None,
         progress_args: tuple = (),
-    ) -> Union[str, List[str]]: ...
+    ) -> Union[str, List[str], None]: ...
 
     @overload
     async def download_media(
@@ -94,7 +104,7 @@ class DownloadMedia:
         block: Literal[True] = True,
         progress: Optional[Callable] = None,
         progress_args: tuple = (),
-    ) -> Union[BinaryIO, List[BinaryIO]]: ...
+    ) -> Union[BinaryIO, List[BinaryIO], None]: ...
 
     @overload
     async def download_media(

--- a/pyrogram/methods/messages/forward_messages.py
+++ b/pyrogram/methods/messages/forward_messages.py
@@ -17,13 +17,51 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import Iterable, List, Optional, Union
+from typing import Iterable, List, Optional, Union, overload
 
 import pyrogram
 from pyrogram import raw, types, utils
 
 
 class ForwardMessages:
+    @overload
+    async def forward_messages(
+        self: "pyrogram.Client",
+        chat_id: Union[int, str],
+        from_chat_id: Union[int, str],
+        message_ids: int,
+        message_thread_id: Optional[int] = None,
+        disable_notification: Optional[bool] = None,
+        schedule_date: Optional[datetime] = None,
+        repeat_period: Optional[int] = None,
+        hide_sender_name: Optional[bool] = None,
+        hide_captions: Optional[bool] = None,
+        protect_content: Optional[bool] = None,
+        allow_paid_broadcast: Optional[bool] = None,
+        video_start_timestamp: Optional[int] = None,
+        reply_parameters: Optional["types.ReplyParameters"] = None,
+        paid_message_star_count: Optional[int] = None
+    ) -> Optional["types.Message"]: ...
+
+    @overload
+    async def forward_messages(
+        self: "pyrogram.Client",
+        chat_id: Union[int, str],
+        from_chat_id: Union[int, str],
+        message_ids: Iterable[int],
+        message_thread_id: Optional[int] = None,
+        disable_notification: Optional[bool] = None,
+        schedule_date: Optional[datetime] = None,
+        repeat_period: Optional[int] = None,
+        hide_sender_name: Optional[bool] = None,
+        hide_captions: Optional[bool] = None,
+        protect_content: Optional[bool] = None,
+        allow_paid_broadcast: Optional[bool] = None,
+        video_start_timestamp: Optional[int] = None,
+        reply_parameters: Optional["types.ReplyParameters"] = None,
+        paid_message_star_count: Optional[int] = None
+    ) -> List["types.Message"]: ...
+
     async def forward_messages(
         self: "pyrogram.Client",
         chat_id: Union[int, str],
@@ -40,7 +78,7 @@ class ForwardMessages:
         video_start_timestamp: Optional[int] = None,
         reply_parameters: Optional["types.ReplyParameters"] = None,
         paid_message_star_count: Optional[int] = None
-    ) -> Union["types.Message", List["types.Message"]]:
+    ) -> Optional[Union["types.Message", List["types.Message"]]]:
         """Forward messages of any kind.
 
         .. include:: /_includes/usable-by/users-bots.rst
@@ -98,8 +136,9 @@ class ForwardMessages:
                 The number of Telegram Stars the user agreed to pay to send the messages.
 
         Returns:
-            :obj:`~pyrogram.types.Message` | List of :obj:`~pyrogram.types.Message`: In case *message_ids* was not
-            a list, a single message is returned, otherwise a list of messages is returned.
+            :obj:`~pyrogram.types.Message` | List of :obj:`~pyrogram.types.Message` | ``None``: In case *message_ids*
+            was not a list, a single message is returned, or None if nothing was forwarded, otherwise a list of
+            messages is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/messages/forward_messages.py
+++ b/pyrogram/methods/messages/forward_messages.py
@@ -178,11 +178,6 @@ class ForwardMessages:
 
         messages = await utils.parse_messages(client=self, messages=r)
 
-        # NOTE: `parse_messages()` reads `r.updates` and keeps only the new and edited message
-        #       updates out of it, so an answer carrying none of those parses to an empty list.
-        #       `messages.forwardMessages` is declared to return `Updates`, and five of that type's
-        #       seven constructors have no `updates` vector at all: `updatesTooLong`, `updateShort`,
-        #       `updateShortMessage`, `updateShortChatMessage` and `updateShortSentMessage`. None of
-        #       them is an error, and all of them parse to nothing, so `messages` can be empty on a
-        #       request that succeeded.
+        # NOTE: `parse_messages()` reads `r.updates`, and five of the seven `Updates` constructors
+        #       carry no `updates` vector at all, so a successful answer can parse to nothing.
         return messages if is_iterable else messages[0] if messages else None

--- a/pyrogram/methods/messages/forward_messages.py
+++ b/pyrogram/methods/messages/forward_messages.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import Iterable, List, Union
+from typing import Iterable, List, Optional, Union
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -29,17 +29,17 @@ class ForwardMessages:
         chat_id: Union[int, str],
         from_chat_id: Union[int, str],
         message_ids: Union[int, Iterable[int]],
-        message_thread_id: int = None,
-        disable_notification: bool = None,
-        schedule_date: datetime = None,
-        repeat_period: int = None,
-        hide_sender_name: bool = None,
-        hide_captions: bool = None,
-        protect_content: bool = None,
-        allow_paid_broadcast: bool = None,
-        video_start_timestamp: int = None,
-        reply_parameters: "types.ReplyParameters" = None,
-        paid_message_star_count: int = None
+        message_thread_id: Optional[int] = None,
+        disable_notification: Optional[bool] = None,
+        schedule_date: Optional[datetime] = None,
+        repeat_period: Optional[int] = None,
+        hide_sender_name: Optional[bool] = None,
+        hide_captions: Optional[bool] = None,
+        protect_content: Optional[bool] = None,
+        allow_paid_broadcast: Optional[bool] = None,
+        video_start_timestamp: Optional[int] = None,
+        reply_parameters: Optional["types.ReplyParameters"] = None,
+        paid_message_star_count: Optional[int] = None
     ) -> Union["types.Message", List["types.Message"]]:
         """Forward messages of any kind.
 

--- a/pyrogram/methods/messages/forward_messages.py
+++ b/pyrogram/methods/messages/forward_messages.py
@@ -137,8 +137,8 @@ class ForwardMessages:
 
         Returns:
             :obj:`~pyrogram.types.Message` | List of :obj:`~pyrogram.types.Message` | ``None``: In case *message_ids*
-            was not a list, a single message is returned, or None if nothing was forwarded, otherwise a list of
-            messages is returned.
+            was not a list, a single message is returned, otherwise a list of messages is returned. In case
+            *message_ids* was not a list and the answer carried no message, None is returned.
 
         Example:
             .. code-block:: python
@@ -178,4 +178,11 @@ class ForwardMessages:
 
         messages = await utils.parse_messages(client=self, messages=r)
 
+        # NOTE: `parse_messages()` reads `r.updates` and keeps only the new and edited message
+        #       updates out of it, so an answer carrying none of those parses to an empty list.
+        #       `messages.forwardMessages` is declared to return `Updates`, and five of that type's
+        #       seven constructors have no `updates` vector at all: `updatesTooLong`, `updateShort`,
+        #       `updateShortMessage`, `updateShortChatMessage` and `updateShortSentMessage`. None of
+        #       them is an error, and all of them parse to nothing, so `messages` can be empty on a
+        #       request that succeeded.
         return messages if is_iterable else messages[0] if messages else None

--- a/pyrogram/methods/messages/forward_messages.py
+++ b/pyrogram/methods/messages/forward_messages.py
@@ -178,6 +178,4 @@ class ForwardMessages:
 
         messages = await utils.parse_messages(client=self, messages=r)
 
-        # NOTE: `parse_messages()` reads `r.updates`, and five of the seven `Updates` constructors
-        #       carry no `updates` vector at all, so a successful answer can parse to nothing.
         return messages if is_iterable else messages[0] if messages else None

--- a/pyrogram/methods/messages/get_direct_messages_chat_topic_history.py
+++ b/pyrogram/methods/messages/get_direct_messages_chat_topic_history.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import AsyncGenerator, Union
+from typing import AsyncIterator, Union
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -71,7 +71,7 @@ class GetDirectMessagesChatTopicHistory:
         min_id: int = 0,
         max_id: int = 0,
         reverse: bool = False
-    ) -> AsyncGenerator["types.Message", None]:
+    ) -> AsyncIterator["types.Message"]:
         """Return messages in the topic in a channel direct messages chat administered by the current user.
 
         The messages are returned in reverse chronological order.

--- a/pyrogram/methods/messages/get_discussion_replies.py
+++ b/pyrogram/methods/messages/get_discussion_replies.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, Optional, AsyncGenerator
+from typing import Union, Optional, AsyncIterator
 
 import pyrogram
 from pyrogram import types, raw
@@ -28,7 +28,7 @@ class GetDiscussionReplies:
         chat_id: Union[int, str],
         message_id: int,
         limit: int = 0,
-    ) -> AsyncGenerator["types.Message", None]:
+    ) -> AsyncIterator["types.Message"]:
         """Get the message replies of a discussion thread.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/messages/get_messages.py
+++ b/pyrogram/methods/messages/get_messages.py
@@ -161,9 +161,9 @@ class GetMessages:
                 Defaults to 1.
 
         Returns:
-            :obj:`~pyrogram.types.Message` | List of :obj:`~pyrogram.types.Message` | ``None``: In case
-            *message_ids* was not a list, a single message is returned, otherwise a list of messages is
-            returned. None is returned when *message_ids* was not a list and the message does not exist.
+            :obj:`~pyrogram.types.Message` | List of :obj:`~pyrogram.types.Message` | ``None``: In case *message_ids*
+            was not a list, a single message is returned, otherwise a list of messages is returned. In case
+            *message_ids* was not a list and the message does not exist, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/messages/get_messages.py
+++ b/pyrogram/methods/messages/get_messages.py
@@ -161,8 +161,9 @@ class GetMessages:
                 Defaults to 1.
 
         Returns:
-            :obj:`~pyrogram.types.Message` | List of :obj:`~pyrogram.types.Message`: In case *message_ids* was not
-            a list, a single message is returned, otherwise a list of messages is returned.
+            :obj:`~pyrogram.types.Message` | List of :obj:`~pyrogram.types.Message` | ``None``: In case
+            *message_ids* was not a list, a single message is returned, otherwise a list of messages is
+            returned. None is returned when *message_ids* was not a list and the message does not exist.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/messages/search_global.py
+++ b/pyrogram/methods/messages/search_global.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncGenerator, Optional
+from typing import AsyncIterator, Optional
 
 import pyrogram
 from pyrogram import raw, enums
@@ -33,7 +33,7 @@ class SearchGlobal:
         groups_only: Optional[bool] = None,
         users_only: Optional[bool] = None,
         limit: int = 0,
-    ) -> AsyncGenerator["types.Message", None]:
+    ) -> AsyncIterator["types.Message"]:
         """Search messages globally from all of your chats.
 
         If you want to get the messages count only, see :meth:`~pyrogram.Client.search_global_count`.

--- a/pyrogram/methods/messages/search_messages.py
+++ b/pyrogram/methods/messages/search_messages.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List, AsyncGenerator, Optional
+from typing import Union, List, AsyncIterator, Optional
 from datetime import datetime
 
 import pyrogram
@@ -81,7 +81,7 @@ class SearchMessages:
         limit: Optional[int] = 0,
         from_user: Optional[Union[int, str]] = None,
         message_thread_id: Optional[int] = None
-    ) -> AsyncGenerator["types.Message", None]:
+    ) -> AsyncIterator["types.Message"]:
         """Search for text and media messages inside a specific chat.
 
         If you want to get the messages count only, see :meth:`~pyrogram.Client.search_messages_count`.

--- a/pyrogram/methods/messages/search_posts.py
+++ b/pyrogram/methods/messages/search_posts.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncGenerator
+from typing import AsyncIterator
 
 import pyrogram
 from pyrogram import raw
@@ -29,7 +29,7 @@ class SearchPosts:
         self: "pyrogram.Client",
         hashtag: str,
         limit: int = 0,
-    ) -> AsyncGenerator["types.Message", None]:
+    ) -> AsyncIterator["types.Message"]:
         """Search posts globally by hashtag.
 
         If you want to get the posts count only, see :meth:`~pyrogram.Client.search_posts_count`.

--- a/pyrogram/methods/messages/send_cached_media.py
+++ b/pyrogram/methods/messages/send_cached_media.py
@@ -139,7 +139,8 @@ class SendCachedMedia:
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent media message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent media message is returned, otherwise,
+            in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/messages/send_checklist.py
+++ b/pyrogram/methods/messages/send_checklist.py
@@ -47,7 +47,7 @@ class SendChecklist:
                 "types.ForceReply"
             ]
         ] = None,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Send a new checklist.
 
         .. include:: /_includes/usable-by/users-bots.rst
@@ -96,7 +96,8 @@ class SendChecklist:
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent checklist message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent checklist message is returned,
+            otherwise, in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/messages/send_contact.py
+++ b/pyrogram/methods/messages/send_contact.py
@@ -59,7 +59,7 @@ class SendContact:
         parse_mode: Optional["enums.ParseMode"] = None,
         quote_entities: Optional[List["types.MessageEntity"]] = None,
         quote_offset: Optional[int] = None,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Send phone contacts.
 
         .. include:: /_includes/usable-by/users-bots.rst
@@ -136,7 +136,8 @@ class SendContact:
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent contact message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent contact message is returned,
+            otherwise, in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/messages/send_dice.py
+++ b/pyrogram/methods/messages/send_dice.py
@@ -118,7 +118,8 @@ class SendDice:
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent dice message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent dice message is returned, otherwise,
+            in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/messages/send_location.py
+++ b/pyrogram/methods/messages/send_location.py
@@ -61,7 +61,7 @@ class SendLocation:
         parse_mode: Optional["enums.ParseMode"] = None,
         quote_entities: Optional[List["types.MessageEntity"]] = None,
         quote_offset: Optional[int] = None,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Send points on the map.
 
         .. include:: /_includes/usable-by/users-bots.rst
@@ -148,7 +148,8 @@ class SendLocation:
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent location message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent location message is returned,
+            otherwise, in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/messages/send_message.py
+++ b/pyrogram/methods/messages/send_message.py
@@ -63,7 +63,7 @@ class SendMessage:
         quote_entities: Optional[List["types.MessageEntity"]] = None,
         quote_offset: Optional[int] = None,
         disable_web_page_preview: Optional[bool] = None, # TODO: Remove later
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Send text messages.
 
         .. include:: /_includes/usable-by/users-bots.rst
@@ -144,7 +144,8 @@ class SendMessage:
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent text message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent text message is returned,
+            otherwise, in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/messages/send_poll.py
+++ b/pyrogram/methods/messages/send_poll.py
@@ -66,7 +66,7 @@ class SendPoll:
                 "types.ForceReply"
             ]
         ] = None,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """A message with a poll.
 
         .. note::
@@ -193,7 +193,8 @@ class SendPoll:
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent poll message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent poll message is returned,
+            otherwise, in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/messages/send_rich_message.py
+++ b/pyrogram/methods/messages/send_rich_message.py
@@ -48,7 +48,7 @@ class SendRichMessage:
                 "types.ForceReply",
             ]
         ] = None,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Send text messages.
 
         .. include:: /_includes/usable-by/users-bots.rst
@@ -107,7 +107,8 @@ class SendRichMessage:
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent text message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent text message is returned,
+            otherwise, in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/messages/send_screenshot_notification.py
+++ b/pyrogram/methods/messages/send_screenshot_notification.py
@@ -26,7 +26,7 @@ class SendScreenshotNotification:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         reply_parameters: Optional["types.ReplyParameters"] = None
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Notify the other user in a private chat that a screenshot of the chat was taken.
 
         .. include:: /_includes/usable-by/users.rst
@@ -41,7 +41,8 @@ class SendScreenshotNotification:
                 Describes reply parameters for the message that is being sent.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent service message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent service message is returned,
+            otherwise, in case the server answered with no message, None is returned.
         """
 
         r = await self.invoke(

--- a/pyrogram/methods/messages/send_venue.py
+++ b/pyrogram/methods/messages/send_venue.py
@@ -61,7 +61,7 @@ class SendVenue:
         parse_mode: Optional["enums.ParseMode"] = None,
         quote_entities: Optional[List["types.MessageEntity"]] = None,
         quote_offset: Optional[int] = None,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Send information about a venue.
 
         .. include:: /_includes/usable-by/users-bots.rst
@@ -145,7 +145,8 @@ class SendVenue:
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent venue message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent venue message is returned,
+            otherwise, in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/messages/send_web_page.py
+++ b/pyrogram/methods/messages/send_web_page.py
@@ -61,7 +61,7 @@ class SendWebPage:
         quote_text: Optional[str] = None,
         quote_entities: Optional[List["types.MessageEntity"]] = None,
         quote_offset: Optional[int] = None,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Send Web Page Preview.
 
         .. include:: /_includes/usable-by/users-bots.rst
@@ -137,7 +137,8 @@ class SendWebPage:
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/messages/start_bot.py
+++ b/pyrogram/methods/messages/start_bot.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from typing import Optional, Union
 
 import pyrogram
 from pyrogram import raw
@@ -28,7 +28,7 @@ class StartBot:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         param: str = ""
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Start bot
 
         .. include:: /_includes/usable-by/users.rst
@@ -43,7 +43,8 @@ class StartBot:
                 Defaults to "" (empty string).
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/messages/stream_media.py
+++ b/pyrogram/methods/messages/stream_media.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import math
-from typing import Union, Optional, BinaryIO
+from typing import AsyncIterator, Union
 
 import pyrogram
 from pyrogram import types
@@ -30,7 +30,7 @@ class StreamMedia:
         message: Union["types.Message", str],
         limit: int = 0,
         offset: int = 0
-    ) -> Optional[Union[str, BinaryIO]]:
+    ) -> AsyncIterator[bytes]:
         """Stream the media from a message chunk by chunk.
 
         You can use this method to partially download a file into memory or to selectively download chunks of file.

--- a/pyrogram/methods/payments/buy_gift_upgrade.py
+++ b/pyrogram/methods/payments/buy_gift_upgrade.py
@@ -17,10 +17,10 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from typing import Optional, Union
+from typing import Union
 
 import pyrogram
-from pyrogram import raw, types
+from pyrogram import raw
 
 
 class BuyGiftUpgrade:
@@ -29,7 +29,7 @@ class BuyGiftUpgrade:
         owner_id: Union[int, str],
         prepaid_upgrade_hash: str,
         star_count: int
-    ) -> Optional["types.Message"]:
+    ) -> bool:
         """Pays for upgrade of a regular gift that is owned by another user or channel chat.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/payments/get_chat_gifts.py
+++ b/pyrogram/methods/payments/get_chat_gifts.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union, AsyncGenerator
+from typing import Optional, Union, AsyncIterator
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -38,7 +38,7 @@ class GetChatGifts:
         sort_by_price: Optional[bool] = None,
         limit: int = 0,
         offset: str = ""
-    ) -> AsyncGenerator["types.Gift", None]:
+    ) -> AsyncIterator["types.Gift"]:
         """Get all gifts owned by specified chat.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/pyrogram/methods/payments/get_gifts_for_crafting.py
+++ b/pyrogram/methods/payments/get_gifts_for_crafting.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncGenerator
+from typing import AsyncIterator
 
 import pyrogram
 from pyrogram import raw, types
@@ -27,7 +27,7 @@ class GetGiftsForCrafting:
         self: "pyrogram.Client",
         regular_gift_id: int,
         limit: int = 0
-    ) -> AsyncGenerator["types.Gift", None]:
+    ) -> AsyncIterator["types.Gift"]:
         """Returns upgraded gifts of the current user that can be used to craft another gifts.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/payments/gift_premium_with_stars.py
+++ b/pyrogram/methods/payments/gift_premium_with_stars.py
@@ -50,7 +50,8 @@ class GiftPremiumWithStars:
                 The number of Telegram Stars to pay for subscription.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise,
+            in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/payments/process_gift_purchase_offer.py
+++ b/pyrogram/methods/payments/process_gift_purchase_offer.py
@@ -41,8 +41,8 @@ class ProcessGiftPurchaseOffer:
                 Pass False to reject it.
 
         Returns:
-            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent Message is returned,
-            otherwise, in case the server answered with no message, None is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
         """
         r = await self.invoke(
             raw.functions.payments.ResolveStarGiftOffer(

--- a/pyrogram/methods/payments/process_gift_purchase_offer.py
+++ b/pyrogram/methods/payments/process_gift_purchase_offer.py
@@ -16,6 +16,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Optional
+
 import pyrogram
 from pyrogram import raw, types, utils
 
@@ -25,7 +27,7 @@ class ProcessGiftPurchaseOffer:
         self: "pyrogram.Client",
         message_id: int,
         accept: bool
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Handles a pending gift purchase offer.
 
         .. include:: /_includes/usable-by/users.rst
@@ -39,7 +41,8 @@ class ProcessGiftPurchaseOffer:
                 Pass False to reject it.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent Message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent Message is returned,
+            otherwise, in case the server answered with no message, None is returned.
         """
         r = await self.invoke(
             raw.functions.payments.ResolveStarGiftOffer(

--- a/pyrogram/methods/payments/search_gifts_for_resale.py
+++ b/pyrogram/methods/payments/search_gifts_for_resale.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Optional, AsyncGenerator
+from typing import List, Optional, AsyncIterator
 
 import pyrogram
 from pyrogram import enums, raw, types
@@ -32,7 +32,7 @@ class SearchGiftsForResale:
         attributes: Optional[List["types.UpgradedGiftAttributeId"]] = None,
         limit: int = 0,
         offset: str = ""
-    ) -> AsyncGenerator["types.Gift", None]:
+    ) -> AsyncIterator["types.Gift"]:
         """Get upgraded gifts that can be bought from other owners.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/payments/send_gift.py
+++ b/pyrogram/methods/payments/send_gift.py
@@ -65,7 +65,8 @@ class SendGift:
                 Pass True to additionally pay for the gift upgrade and allow the receiver to upgrade it for free.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise,
+            in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/payments/send_gift_purchase_offer.py
+++ b/pyrogram/methods/payments/send_gift_purchase_offer.py
@@ -55,8 +55,8 @@ class SendGiftPurchaseOffer:
                 Pass User.paid_message_star_count for users and None otherwise.
 
         Returns:
-            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent Message is returned,
-            otherwise, in case the server answered with no message, None is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
         """
         match = self.UPGRADED_GIFT_RE.match(gift_name)
 

--- a/pyrogram/methods/payments/send_gift_purchase_offer.py
+++ b/pyrogram/methods/payments/send_gift_purchase_offer.py
@@ -30,7 +30,7 @@ class SendGiftPurchaseOffer:
         price: "types.GiftResalePrice",
         duration: int,
         paid_message_star_count: Optional[int] = None
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Sends an offer to purchase an upgraded gift.
 
         .. include:: /_includes/usable-by/users.rst
@@ -55,7 +55,8 @@ class SendGiftPurchaseOffer:
                 Pass User.paid_message_star_count for users and None otherwise.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent Message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent Message is returned,
+            otherwise, in case the server answered with no message, None is returned.
         """
         match = self.UPGRADED_GIFT_RE.match(gift_name)
 

--- a/pyrogram/methods/payments/send_resold_gift.py
+++ b/pyrogram/methods/payments/send_resold_gift.py
@@ -51,7 +51,8 @@ class SendResoldGift:
                 The price that the user agreed to pay for the gift.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise,
+            in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/payments/transfer_gift.py
+++ b/pyrogram/methods/payments/transfer_gift.py
@@ -56,7 +56,8 @@ class TransferGift:
                 For bots only.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise,
+            in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/payments/upgrade_gift.py
+++ b/pyrogram/methods/payments/upgrade_gift.py
@@ -57,7 +57,8 @@ class UpgradeGift:
                 For bots only.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise,
+            in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/phone/get_call_members.py
+++ b/pyrogram/methods/phone/get_call_members.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, AsyncGenerator
+from typing import Union, AsyncIterator
 
 import pyrogram
 from pyrogram import types, raw
@@ -27,7 +27,7 @@ class GetCallMembers:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         limit: int = 0
-    ) -> AsyncGenerator["types.GroupCallMember", None]:
+    ) -> AsyncIterator["types.GroupCallMember"]:
         """Get the members list of a chat call.
 
         A chat can be either a basic group or a supergroup.

--- a/pyrogram/methods/stories/copy_story.py
+++ b/pyrogram/methods/stories/copy_story.py
@@ -39,7 +39,7 @@ class CopyStory:
         allowed_users: Optional[List[Union[int, str]]] = None,
         disallowed_users: Optional[List[Union[int, str]]] = None,
         protect_content: Optional[bool] = None
-    ) -> "types.Story":
+    ) -> Optional["types.Story"]:
         """Copy story.
 
         .. include:: /_includes/usable-by/users.rst
@@ -92,7 +92,9 @@ class CopyStory:
                 List of special entities that appear in the new caption, which can be specified instead of *parse_mode*.
 
         Returns:
-            :obj:`~pyrogram.types.Story`: On success, the copied story is returned.
+            :obj:`~pyrogram.types.Story` | ``None``: On success, the copied story is returned, otherwise,
+            in case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`,
+            None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/stories/edit_story_media.py
+++ b/pyrogram/methods/stories/edit_story_media.py
@@ -38,7 +38,7 @@ class EditStoryMedia:
         file_name: Optional[str] = None,
         progress: Optional[Callable] = None,
         progress_args: tuple = ()
-    ) -> "types.Story":
+    ) -> Optional["types.Story"]:
         """Edit story media.
 
         .. include:: /_includes/usable-by/users.rst
@@ -87,7 +87,9 @@ class EditStoryMedia:
                 object or a Client instance in order to edit the message with the updated progress status.
 
         Returns:
-            :obj:`~pyrogram.types.Story`: On success, the edited story is returned.
+            :obj:`~pyrogram.types.Story` | ``None``: On success, the edited story is returned, otherwise,
+            in case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`,
+            None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/stories/forward_story.py
+++ b/pyrogram/methods/stories/forward_story.py
@@ -97,7 +97,8 @@ class ForwardStory:
                 Unique identifier of the message effect to be added to the message; for private chats only.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent story message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent story message is returned, otherwise,
+            in case the server answered with no message, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/stories/get_all_stories.py
+++ b/pyrogram/methods/stories/get_all_stories.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncGenerator, Optional
+from typing import AsyncIterator, Optional
 
 import pyrogram
 from pyrogram import raw
@@ -29,7 +29,7 @@ class GetAllStories:
         next: Optional[bool] = None,
         hidden: Optional[bool] = None,
         state: Optional[str] = None,
-    ) -> AsyncGenerator["types.Story", None]:
+    ) -> AsyncIterator["types.Story"]:
         """Get all active or hidden stories that displayed on the action bar on the homescreen.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/stories/get_archived_stories.py
+++ b/pyrogram/methods/stories/get_archived_stories.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncGenerator, Union
+from typing import AsyncIterator, Union
 
 import pyrogram
 from pyrogram import raw, types
@@ -28,7 +28,7 @@ class GetArchivedStories:
         chat_id: Union[int, str],
         limit: int = 0,
         offset_id: int = 0
-    ) -> AsyncGenerator["types.Story", None]:
+    ) -> AsyncIterator["types.Story"]:
         """Get all archived stories from a chat by using chat identifier.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/stories/get_chat_stories.py
+++ b/pyrogram/methods/stories/get_chat_stories.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncGenerator, Union
+from typing import AsyncIterator, Union
 
 import pyrogram
 from pyrogram import raw
@@ -27,7 +27,7 @@ class GetChatStories:
     async def get_chat_stories(
         self: "pyrogram.Client",
         chat_id: Union[int, str]
-    ) -> AsyncGenerator["types.Story", None]:
+    ) -> AsyncIterator["types.Story"]:
         """Get all non expired stories from a chat by using chat identifier.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/stories/get_pinned_stories.py
+++ b/pyrogram/methods/stories/get_pinned_stories.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncGenerator, Union
+from typing import AsyncIterator, Union
 
 import pyrogram
 from pyrogram import raw
@@ -30,7 +30,7 @@ class GetPinnedStories:
         chat_id: Union[int, str],
         offset_id: int = 0,
         limit: int = 0,
-    ) -> AsyncGenerator["types.Story", None]:
+    ) -> AsyncIterator["types.Story"]:
         """Get all pinned stories from a chat by using chat identifier.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/stories/get_stories.py
+++ b/pyrogram/methods/stories/get_stories.py
@@ -58,9 +58,9 @@ class GetStories:
                 or link to get the content of the story themselves.
 
         Returns:
-            :obj:`~pyrogram.types.Story` | List of :obj:`~pyrogram.types.Story` | ``None``: In case
-            *story_ids* was not a list, a single story is returned, otherwise a list of stories is returned.
-            None is returned when *story_ids* was not a list and the story does not exist.
+            :obj:`~pyrogram.types.Story` | List of :obj:`~pyrogram.types.Story` | ``None``: In case *story_ids* was not
+            a list, a single story is returned, otherwise a list of stories is returned. In case *story_ids* was not a
+            list and the story does not exist, None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/stories/get_stories.py
+++ b/pyrogram/methods/stories/get_stories.py
@@ -58,8 +58,9 @@ class GetStories:
                 or link to get the content of the story themselves.
 
         Returns:
-            :obj:`~pyrogram.types.Story` | List of :obj:`~pyrogram.types.Story`: In case *story_ids* was not
-            a list, a single story is returned, otherwise a list of stories is returned.
+            :obj:`~pyrogram.types.Story` | List of :obj:`~pyrogram.types.Story` | ``None``: In case
+            *story_ids* was not a list, a single story is returned, otherwise a list of stories is returned.
+            None is returned when *story_ids* was not a list and the story does not exist.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/stories/get_stories.py
+++ b/pyrogram/methods/stories/get_stories.py
@@ -17,13 +17,27 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-from typing import Iterable, List, Optional, Union
+from typing import Iterable, List, Optional, Union, overload
 
 import pyrogram
 from pyrogram import raw, types
 
 
 class GetStories:
+    @overload
+    async def get_stories(
+        self: "pyrogram.Client",
+        chat_id: Optional[Union[int, str]] = None,
+        story_ids: Optional[Union[int, str]] = None,
+    ) -> Optional["types.Story"]: ...
+
+    @overload
+    async def get_stories(
+        self: "pyrogram.Client",
+        chat_id: Optional[Union[int, str]],
+        story_ids: Iterable[int],
+    ) -> List["types.Story"]: ...
+
     async def get_stories(
         self: "pyrogram.Client",
         chat_id: Optional[Union[int, str]] = None,

--- a/pyrogram/methods/stories/get_story_views.py
+++ b/pyrogram/methods/stories/get_story_views.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncGenerator, Optional, Union
+from typing import AsyncIterator, Optional, Union
 
 import pyrogram
 from pyrogram import raw, types
@@ -33,7 +33,7 @@ class GetStoryViews:
         reactions_first: Optional[bool] = None,
         forwards_first: Optional[bool] = None,
         query: Optional[str] = None
-    ) -> AsyncGenerator["types.StoryView", None]:
+    ) -> AsyncIterator["types.StoryView"]:
         """Obtain the list of users that have viewed a specific story we posted.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/stories/send_story.py
+++ b/pyrogram/methods/stories/send_story.py
@@ -47,7 +47,7 @@ class SendStory:
         caption_entities: Optional[List["types.MessageEntity"]] = None,
         progress: Optional[Callable] = None,
         progress_args: tuple = (),
-    ) -> "types.Story":
+    ) -> Optional["types.Story"]:
         """Post new story.
 
         .. include:: /_includes/usable-by/users.rst
@@ -136,7 +136,9 @@ class SendStory:
                 object or a Client instance in order to edit the message with the updated progress status.
 
         Returns:
-            :obj:`~pyrogram.types.Story` a single story is returned.
+            :obj:`~pyrogram.types.Story` | ``None``: On success, the sent story is returned, otherwise,
+            in case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`,
+            None is returned.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/users/get_chat_audios.py
+++ b/pyrogram/methods/users/get_chat_audios.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncGenerator, Optional, Union
+from typing import AsyncIterator, Union
 
 import pyrogram
 from pyrogram import raw, types
@@ -27,9 +27,7 @@ class GetChatAudios:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         limit: int = 0,
-    ) -> Optional[
-        AsyncGenerator["types.Audio", None]
-    ]:
+    ) -> AsyncIterator["types.Audio"]:
         """Get a user profile audios sequentially.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/users/get_chat_photos.py
+++ b/pyrogram/methods/users/get_chat_photos.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import Union, AsyncGenerator, Optional
+from typing import Union, AsyncIterator
 
 import pyrogram
 from pyrogram import types, raw, utils
@@ -28,12 +28,7 @@ class GetChatPhotos:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         limit: int = 0,
-    ) -> Optional[
-        Union[
-            AsyncGenerator["types.Photo", None],
-            AsyncGenerator["types.Animation", None]
-        ]
-    ]:
+    ) -> AsyncIterator[Union["types.Photo", "types.Animation"]]:
         """Get a chat or a user profile photos sequentially.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/pyrogram/methods/users/get_users.py
+++ b/pyrogram/methods/users/get_users.py
@@ -26,8 +26,7 @@ from pyrogram import types
 
 class GetUsers:
     # NOTE: `str` is itself an iterable of `str`, so a username matches both overloads.
-    #       The single-user one comes first, which resolves it the way the body does,
-    #       but the two still read as overlapping to a type checker.
+    #       The single-user one comes first, resolving it the way the body does.
     @overload
     async def get_users(  # type: ignore[overload-overlap]
         self: "pyrogram.Client",

--- a/pyrogram/methods/users/get_users.py
+++ b/pyrogram/methods/users/get_users.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
-from typing import Union, List, Iterable
+from typing import Union, List, Iterable, overload
 
 import pyrogram
 from pyrogram import raw
@@ -25,6 +25,21 @@ from pyrogram import types
 
 
 class GetUsers:
+    # NOTE: `str` is itself an iterable of `str`, so a username matches both overloads.
+    #       The single-user one comes first, which resolves it the way the body does,
+    #       but the two still read as overlapping to a type checker.
+    @overload
+    async def get_users(  # type: ignore[overload-overlap]
+        self: "pyrogram.Client",
+        user_ids: Union[int, str]
+    ) -> "types.User": ...
+
+    @overload
+    async def get_users(
+        self: "pyrogram.Client",
+        user_ids: Iterable[Union[int, str]]
+    ) -> List["types.User"]: ...
+
     async def get_users(
         self: "pyrogram.Client",
         user_ids: Union[int, str, Iterable[Union[int, str]]]

--- a/pyrogram/types/messages_and_media/gift.py
+++ b/pyrogram/types/messages_and_media/gift.py
@@ -836,7 +836,8 @@ class Gift(Object):
                 await gift.upgrade()
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
         """
         return await self._client.upgrade_gift(
             owned_gift_id=self.owned_gift_id,
@@ -866,7 +867,8 @@ class Gift(Object):
                 await gift.transfer(to_chat_id=123)
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
         """
         if not self.type == enums.GiftType.UPGRADED:
             raise ValueError("Only upgraded gifts can be transferred.")
@@ -922,7 +924,8 @@ class Gift(Object):
                 await gift.buy()
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
         """
         if new_owner_chat_id is None:
             new_owner_chat_id = "me"
@@ -970,7 +973,8 @@ class Gift(Object):
                 await gift.send("me")
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
         """
         return await self._client.send_gift(
             chat_id=chat_id,
@@ -1027,7 +1031,8 @@ class Gift(Object):
                 Pass User.paid_message_star_count for users and None otherwise.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent Message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
         """
         if not self.can_send_purchase_offer:
             raise ValueError("This gift cannot be purchased via offer.")

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -2560,9 +2560,8 @@ class Message(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -2779,9 +2778,8 @@ class Message(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -2977,9 +2975,8 @@ class Message(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -3186,9 +3183,8 @@ class Message(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -3324,8 +3320,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
-            no message, None is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -3465,8 +3461,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
-            no message, None is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -3654,9 +3650,8 @@ class Message(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -3866,9 +3861,8 @@ class Message(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -3971,8 +3965,8 @@ class Message(Object, Update):
                 If not empty, the first button must launch the game.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
-            no message, None is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -4064,8 +4058,8 @@ class Message(Object, Update):
                 If not empty, the first button must launch the game.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
-            no message, None is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -4611,8 +4605,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
-            no message, None is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -4765,8 +4759,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
-            no message, None is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -5461,9 +5455,8 @@ class Message(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -5675,9 +5668,8 @@ class Message(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -6483,9 +6475,8 @@ class Message(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -6674,9 +6665,8 @@ class Message(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -6818,8 +6808,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
-            no message, None is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -6970,8 +6960,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
-            no message, None is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -7198,9 +7188,8 @@ class Message(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -7455,9 +7444,8 @@ class Message(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -7652,9 +7640,8 @@ class Message(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -7852,9 +7839,8 @@ class Message(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -8036,9 +8022,8 @@ class Message(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -8233,9 +8218,8 @@ class Message(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -8970,8 +8954,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
-            no message, None is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -9078,8 +9062,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
-            no message, None is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -3259,7 +3259,7 @@ class Message(Object, Update):
         quote_text: Optional[str] = None,
         parse_mode: Optional["enums.ParseMode"] = None,
         quote_entities: Optional[List["types.MessageEntity"]] = None,
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_contact` will automatically fill method attributes:
 
         * chat_id
@@ -3324,7 +3324,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
+            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
+            no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -3400,7 +3401,7 @@ class Message(Object, Update):
                 "types.ForceReply"
             ]
         ] = None
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_contact` will automatically fill method attributes:
 
         * chat_id
@@ -3464,7 +3465,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
+            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
+            no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -3927,7 +3929,7 @@ class Message(Object, Update):
 
         quote: Optional[bool] = None,
         reply_to_message_id: Optional[int] = None,
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_game` will automatically fill method attributes:
 
         * chat_id
@@ -3969,7 +3971,8 @@ class Message(Object, Update):
                 If not empty, the first button must launch the game.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
+            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
+            no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -4020,7 +4023,7 @@ class Message(Object, Update):
                 "types.ForceReply"
             ]
         ] = None
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_game` will automatically fill method attributes:
 
         * chat_id
@@ -4061,7 +4064,8 @@ class Message(Object, Update):
                 If not empty, the first button must launch the game.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
+            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
+            no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -4532,7 +4536,7 @@ class Message(Object, Update):
         reply_to_message_id: Optional[int] = None,
         quote_text: Optional[str] = None,
         quote_entities: Optional[List["types.MessageEntity"]] = None,
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_location` will automatically fill method attributes:
 
         * chat_id
@@ -4607,7 +4611,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
+            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
+            no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -4686,7 +4691,7 @@ class Message(Object, Update):
                 "types.ForceReply"
             ]
         ] = None
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_location` will automatically fill method attributes:
 
         * chat_id
@@ -4760,7 +4765,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
+            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
+            no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -6736,7 +6742,7 @@ class Message(Object, Update):
         quote_text: Optional[str] = None,
         parse_mode: Optional["enums.ParseMode"] = None,
         quote_entities: Optional[List["types.MessageEntity"]] = None,
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_venue` will automatically fill method attributes:
 
         * chat_id
@@ -6808,7 +6814,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
+            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
+            no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -6888,7 +6895,7 @@ class Message(Object, Update):
                 "types.ForceReply"
             ]
         ] = None
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_venue` will automatically fill method attributes:
 
         * chat_id
@@ -6959,7 +6966,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
+            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
+            no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -8742,7 +8750,7 @@ class Message(Object, Update):
         quote_text: Optional[str] = None,
         parse_mode: Optional["enums.ParseMode"] = None,
         quote_entities: Optional[List["types.MessageEntity"]] = None,
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_inline_bot_result` will automatically fill method attributes:
 
         * chat_id
@@ -8776,7 +8784,8 @@ class Message(Object, Update):
                 The number of Telegram Stars the user agreed to pay to send the messages.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -8826,7 +8835,7 @@ class Message(Object, Update):
         direct_messages_topic_id: Optional[int] = None,
         reply_parameters: Optional["types.ReplyParameters"] = None,
         paid_message_star_count: Optional[int] = None
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_inline_bot_result` will automatically fill method attributes:
 
         * chat_id
@@ -8859,7 +8868,8 @@ class Message(Object, Update):
                 The number of Telegram Stars the user agreed to pay to send the messages.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -8902,7 +8912,7 @@ class Message(Object, Update):
         ] = None,
 
         quote: Optional[bool] = None,
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_checklist` will automatically fill method attributes:
 
         * chat_id
@@ -8954,7 +8964,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
+            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
+            no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -9010,7 +9021,7 @@ class Message(Object, Update):
                 "types.ForceReply"
             ]
         ] = None,
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_checklist` will automatically fill method attributes:
 
         * chat_id
@@ -9061,7 +9072,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
+            On success, the sent :obj:`~pyrogram.types.Message` is returned, otherwise, in case the server answered with
+            no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -9633,7 +9645,7 @@ class Message(Object, Update):
         reply_to_message_id: Optional[int] = None,
         quote_text: Optional[str] = None,
         quote_entities: Optional[List["types.MessageEntity"]] = None,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.copy_message` will automatically fill method attributes:
 
         * from_chat_id
@@ -9696,7 +9708,8 @@ class Message(Object, Update):
                 Pass None to remove the reply markup.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the copied message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the copied message is returned, otherwise, in case
+            no message was sent, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -5017,7 +5017,7 @@ class Message(Object, Update):
         reply_to_message_id: Optional[int] = None,
         quote_text: Optional[str] = None,
         quote_entities: Optional[List["types.MessageEntity"]] = None,
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_message` will automatically fill method attributes:
 
         * chat_id
@@ -5098,7 +5098,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -5186,7 +5187,7 @@ class Message(Object, Update):
                 "types.ForceReply"
             ]
         ] = None
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_message` will automatically fill method attributes:
 
         * chat_id
@@ -5266,7 +5267,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -5757,7 +5759,7 @@ class Message(Object, Update):
                 "types.ForceReply"
             ]
         ] = None,
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_poll` will automatically fill method attributes:
 
         * chat_id
@@ -5882,7 +5884,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent poll message is returned, otherwise, in case
+            the server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -5968,7 +5971,7 @@ class Message(Object, Update):
                 "types.ForceReply"
             ]
         ] = None,
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_poll` will automatically fill method attributes:
 
         * chat_id
@@ -6092,7 +6095,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent poll message is returned, otherwise, in case
+            the server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -8486,7 +8490,7 @@ class Message(Object, Update):
         reply_to_message_id: Optional[int] = None,
         quote_text: Optional[str] = None,
         quote_entities: Optional[List["types.MessageEntity"]] = None,
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_cached_media` will automatically fill method attributes:
 
         * chat_id
@@ -8542,7 +8546,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent media message is returned, otherwise, in
+            case the server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -8609,7 +8614,7 @@ class Message(Object, Update):
                 "types.ForceReply"
             ]
         ] = None
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_cached_media` will automatically fill method attributes:
 
         * chat_id
@@ -8664,7 +8669,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent media message is returned, otherwise, in
+            case the server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -9113,7 +9119,7 @@ class Message(Object, Update):
                 "types.ForceReply"
             ]
         ] = None,
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_rich_message` will automatically fill method attributes:
 
         * chat_id
@@ -9155,7 +9161,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent text message is returned, otherwise, in case
+            the server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -9199,7 +9206,7 @@ class Message(Object, Update):
                 "types.ForceReply"
             ]
         ] = None,
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_rich_message` will automatically fill method attributes:
 
         * chat_id
@@ -9240,7 +9247,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent text message is returned, otherwise, in case
+            the server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -9469,7 +9477,7 @@ class Message(Object, Update):
         live_period: Optional[int] = None,
         heading: Optional[int] = None,
         proximity_alert_radius: Optional[int] = None
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Use this method to edit live location messages.
 
         Parameters:
@@ -9499,7 +9507,8 @@ class Message(Object, Update):
                 Can't be enabled in channels and Saved Messages.
 
         Returns:
-            On success, the edited :obj:`~pyrogram.types.Message` is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the edited message is returned,
+            otherwise, in case the server answered with no message, None is returned.
         """
         r = await self._client.invoke(
             raw.functions.messages.EditMessage(
@@ -9522,11 +9531,12 @@ class Message(Object, Update):
 
     async def stop_live_location(
         self
-    ) -> "Message":
+    ) -> Optional["Message"]:
         """Use this method to stop updating a live location message before live_period expires.
 
         Returns:
-            On success, the edited :obj:`~pyrogram.types.Message` is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the edited message is returned,
+            otherwise, in case the server answered with no message, None is returned.
         """
         r = await self._client.invoke(
             raw.functions.messages.EditMessage(
@@ -9553,7 +9563,7 @@ class Message(Object, Update):
         allow_paid_broadcast: Optional[bool] = None,
         video_start_timestamp: Optional[int] = None,
         paid_message_star_count: Optional[int] = None
-    ) -> Union["types.Message", List["types.Message"]]:
+    ) -> Optional[Union['types.Message', List['types.Message']]]:
         """Shortcut for method :obj:`~pyrogram.Client.forward_messages` will automatically fill method attributes:
 
         * from_chat_id
@@ -9598,7 +9608,8 @@ class Message(Object, Update):
                 The number of Telegram Stars the user agreed to pay to send the messages.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the forwarded message is returned.
+            :obj:`~pyrogram.types.Message` | List of :obj:`~pyrogram.types.Message` | ``None``: On success, the
+            forwarded messages are returned, otherwise, in case the server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -10463,26 +10474,28 @@ class Message(Object, Update):
             input_invoice=invoice
         )
 
-    async def accept_gift_purchase_offer(self) -> "types.Message":
+    async def accept_gift_purchase_offer(self) -> Optional["types.Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.process_gift_purchase_offer` will automatically fill method attributes:
 
         * message_id
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
         """
         return await self._client.process_gift_purchase_offer(
             message_id=self.id,
             accept=True
         )
 
-    async def reject_gift_purchase_offer(self) -> "types.Message":
+    async def reject_gift_purchase_offer(self) -> Optional["types.Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.process_gift_purchase_offer` will automatically fill method attributes:
 
         * message_id
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
         """
         return await self._client.process_gift_purchase_offer(
             message_id=self.id,

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -4241,7 +4241,8 @@ class Message(Object, Update):
                 List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent invoice message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent invoice message is returned, otherwise, in
+            case the server answered with no message, None is returned.
         """
         if reply_parameters is None:
             reply_parameters = types.ReplyParameters(
@@ -4454,7 +4455,8 @@ class Message(Object, Update):
                 List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent invoice message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent invoice message is returned, otherwise, in
+            case the server answered with no message, None is returned.
         """
         if message_thread_id is None:
             message_thread_id = self.message_thread_id
@@ -6210,7 +6212,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent dice message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent dice message is returned, otherwise, in case
+            the server answered with no message, None is returned.
         """
         if reply_parameters is None:
             reply_parameters = types.ReplyParameters(
@@ -6316,7 +6319,8 @@ class Message(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent dice message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent dice message is returned, otherwise, in case
+            the server answered with no message, None is returned.
         """
         if message_thread_id is None:
             message_thread_id = self.message_thread_id
@@ -10357,7 +10361,8 @@ class Message(Object, Update):
                 Applicable to private chats only. Defaults to False.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the service message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the service message is returned, otherwise, in case
+            the server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -10267,7 +10267,7 @@ class Message(Object, Update):
         block: bool = True,
         progress: Optional[Callable] = None,
         progress_args: tuple = ()
-    ) -> str:
+    ) -> Optional[Union[str, BinaryIO, List[str], List[BinaryIO]]]:
         """Shortcut for method :obj:`~pyrogram.Client.download_media` will automatically fill method attributes:
 
         * message
@@ -10311,7 +10311,11 @@ class Message(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the absolute path of the downloaded file as string is returned, None otherwise.
+            ``str`` | ``BinaryIO`` | ``List[str]`` | ``List[BinaryIO]`` | ``None``: On success, the absolute path of the
+            downloaded file is returned. In case ``in_memory=True``, a binary file-like object with its attribute
+            ".name" set is returned. If the message contains multiple media (purchased paid media), a list of paths or
+            binary file-like objects is returned. In case the download failed or was deliberately stopped with
+            :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.

--- a/pyrogram/types/messages_and_media/story.py
+++ b/pyrogram/types/messages_and_media/story.py
@@ -908,7 +908,8 @@ class Story(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent media message is returned, otherwise, in
+            case the server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -2037,7 +2038,8 @@ class Story(Object, Update):
                 The number of Telegram Stars the user agreed to pay to send the messages.
 
         Returns:
-            On success, the forwarded Message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent story message is returned, otherwise, in
+            case the server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.

--- a/pyrogram/types/messages_and_media/story.py
+++ b/pyrogram/types/messages_and_media/story.py
@@ -458,7 +458,7 @@ class Story(Object, Update):
         ]] = None,
 
         disable_web_page_preview: Optional[bool] = None,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Bound method *reply_text* of :obj:`~pyrogram.types.Story`.
 
         An alias exists as *reply*.
@@ -513,7 +513,8 @@ class Story(Object, Update):
                 instructions to remove reply keyboard or to force a reply from the user.
 
         Returns:
-            On success, the sent Message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.

--- a/pyrogram/types/messages_and_media/story.py
+++ b/pyrogram/types/messages_and_media/story.py
@@ -665,9 +665,8 @@ class Story(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -817,9 +816,8 @@ class Story(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -1103,9 +1101,8 @@ class Story(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -1215,9 +1212,8 @@ class Story(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -1394,9 +1390,8 @@ class Story(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -1535,9 +1530,8 @@ class Story(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -1667,9 +1661,8 @@ class Story(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the sent :obj:`~pyrogram.types.Message` is returned.
-            In case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned
-            instead.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -1849,8 +1842,8 @@ class Story(Object, Update):
                 pass a binary file-like object with its attribute ".name" set for in-memory uploads.
 
         Returns:
-            On success, the edited :obj:`~pyrogram.types.Story` is returned, otherwise, in case the upload is
-            deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
+            :obj:`~pyrogram.types.Story` | ``None``: On success, the edited story is returned, otherwise, in case the
+            upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -2120,7 +2113,10 @@ class Story(Object, Update):
                 You can either keep ``*args`` or add every single extra argument in your function signature.
 
         Returns:
-            On success, the absolute path of the downloaded file as string is returned, None otherwise.
+            ``str`` | ``BinaryIO`` | ``None``: On success, the absolute path of the downloaded file is returned,
+            otherwise, in case ``in_memory=True``, a binary file-like object with its attribute ".name" set is returned.
+            In case the download failed or was deliberately stopped with
+            :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.

--- a/pyrogram/types/messages_and_media/story.py
+++ b/pyrogram/types/messages_and_media/story.py
@@ -1706,7 +1706,7 @@ class Story(Object, Update):
         allowed_users: Optional[List[int]] = None,
         disallowed_users: Optional[List[int]] = None,
         protect_content: Optional[bool] = None
-    ) -> "types.Story":
+    ) -> Optional["types.Story"]:
         """Bound method *copy* of :obj:`~pyrogram.types.Story`.
 
         Use as a shortcut for:
@@ -1767,7 +1767,8 @@ class Story(Object, Update):
                 Protects the contents of the sent story from forwarding and saving.
 
         Returns:
-            :obj:`~pyrogram.types.Story`: On success, the copied story is returned.
+            :obj:`~pyrogram.types.Story` | ``None``: On success, the copied story is returned, otherwise, in case
+            the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -1820,7 +1821,7 @@ class Story(Object, Update):
     async def edit_media(
         self,
         media: Optional[Union[str, BinaryIO]] = None,
-    ) -> "types.Story":
+    ) -> Optional["types.Story"]:
         """Bound method *edit_media* of :obj:`~pyrogram.types.Story`.
 
         Use as a shortcut for:
@@ -1847,7 +1848,8 @@ class Story(Object, Update):
                 pass a binary file-like object with its attribute ".name" set for in-memory uploads.
 
         Returns:
-            On success, the edited :obj:`~pyrogram.types.Story` is returned.
+            On success, the edited :obj:`~pyrogram.types.Story` is returned, otherwise, in case the upload is
+            deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.

--- a/pyrogram/types/user_and_chats/chat.py
+++ b/pyrogram/types/user_and_chats/chat.py
@@ -1516,7 +1516,7 @@ class Chat(Object):
         """
         return await self._client.unarchive_chats(self.id)
 
-    async def set_title(self, title: str) -> "types.Message":
+    async def set_title(self, title: str) -> Optional["types.Message"]:
         """Bound method *set_title* of :obj:`~pyrogram.types.Chat`.
 
         Use as a shortcut for:
@@ -1538,7 +1538,8 @@ class Chat(Object):
                 New chat title, 1-255 characters.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent service message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent service message is returned, otherwise, in
+            case the server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of Telegram RPC error.
@@ -1582,7 +1583,7 @@ class Chat(Object):
         photo: Optional[Union[str, BinaryIO]] = None,
         video: Optional[Union[str, BinaryIO]] = None,
         video_start_ts: Optional[float] = None,
-    ) -> "types.Message":
+    ) -> Optional["types.Message"]:
         """Bound method *set_photo* of :obj:`~pyrogram.types.Chat`.
 
         Use as a shortcut for:
@@ -1625,7 +1626,8 @@ class Chat(Object):
                 The timestamp in seconds of the video frame to use as photo profile preview.
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the sent service message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the sent service message is returned, otherwise, in
+            case the server answered with no message, None is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -1635,7 +1637,7 @@ class Chat(Object):
             chat_id=self.id, photo=photo, video=video, video_start_ts=video_start_ts
         )
 
-    async def set_ttl(self, ttl_seconds: int) -> "types.Message":
+    async def set_ttl(self, ttl_seconds: int) -> Optional["types.Message"]:
         """Bound method *set_ttl* of :obj:`~pyrogram.types.Chat`.
 
         Use as a shortcut for:
@@ -1653,7 +1655,8 @@ class Chat(Object):
                 await chat.set_ttl(86400)
 
         Returns:
-            :obj:`~pyrogram.types.Message`: On success, the generated service message is returned.
+            :obj:`~pyrogram.types.Message` | ``None``: On success, the generated service message is returned, otherwise,
+            in case the server answered with no message, None is returned.
         """
         return await self._client.set_chat_ttl(chat_id=self.id, ttl_seconds=ttl_seconds)
 

--- a/pyrogram/types/user_and_chats/chat.py
+++ b/pyrogram/types/user_and_chats/chat.py
@@ -546,8 +546,9 @@ class Chat(Object):
         raw (:obj:`~pyrogram.raw.types.UserFull` | :obj:`~pyrogram.raw.types.ChatFull` | :obj:`~pyrogram.raw.types.ChannelFull`, *optional*):
             The raw chat or user object, as received from the Telegram API.
 
-        full_name (``str``, *property*):
+        full_name (``str``, *optional*, *property*):
             Full name of the other party in a private chat, for private chats and bots.
+            None for a chat that has neither a name nor a title.
     """
 
     def __init__(
@@ -1469,7 +1470,7 @@ class Chat(Object):
         )
 
     @property
-    def full_name(self) -> str:
+    def full_name(self) -> Optional[str]:
         return " ".join(filter(None, [self.first_name, self.last_name])) or self.title or None
 
     async def archive(self):

--- a/pyrogram/types/user_and_chats/chat.py
+++ b/pyrogram/types/user_and_chats/chat.py
@@ -18,7 +18,7 @@
 
 import logging
 from datetime import datetime
-from typing import AsyncGenerator, BinaryIO, Dict, List, Optional, Union
+from typing import AsyncIterator, BinaryIO, Dict, List, Optional, Union
 
 import pyrogram
 from pyrogram import enums, raw, types, utils
@@ -1929,7 +1929,7 @@ class Chat(Object):
         query: str = "",
         limit: int = 0,
         filter: "enums.ChatMembersFilter" = enums.ChatMembersFilter.SEARCH,
-    ) -> AsyncGenerator["types.ChatMember", None]:
+    ) -> AsyncIterator["types.ChatMember"]:
         """Bound method *get_members* of :obj:`~pyrogram.types.Chat`.
 
         Use as a shortcut for:

--- a/pyrogram/types/user_and_chats/user.py
+++ b/pyrogram/types/user_and_chats/user.py
@@ -423,8 +423,9 @@ class User(Object, Update):
             ``user.mention("another name")`` for a custom name. To choose a different style
             ("html" or "md"/"markdown") use ``user.mention(style="md")``.
 
-        full_name (``str``, *property*):
+        full_name (``str``, *optional*, *property*):
             Full name of the other party in a private chat, for private chats and bots.
+            None for a user that has neither a first nor a last name, such as a deleted account.
     """
 
     def __init__(
@@ -634,7 +635,7 @@ class User(Object, Update):
         self.raw = raw
 
     @property
-    def full_name(self) -> str:
+    def full_name(self) -> Optional[str]:
         return " ".join(filter(None, [self.first_name, self.last_name])) or None
 
     @property


### PR DESCRIPTION
Closes #340.

The library ships `py.typed`, so a return annotation is a promise a caller's type checker
acts on. Wherever the annotation and the `Returns:` block disagreed, one of them was
lying, and silently — the failure lands in the caller's code, not here. This makes them
agree.

**No runtime behaviour changes, with exactly one deliberate exception**, called out under
*The one behaviour change* below. Everything else in the 90 touched files is an
annotation, a docstring or an import.

## What

### 1. Overloads for the methods whose shape depends on their argument

`download_media()` keeps its overloads, but they now mirror the implementation signature —
same order, same defaults, no keyword-only marker — so every call the implementation
accepts also resolves. `block` becomes the discriminator that decides whether a value
comes back at all, `in_memory` only picks which value:

| call | before | after |
| --- | --- | --- |
| `download_media(message)` | no match, `Any` | `str \| list[str] \| None` |
| `download_media(message, "downloads/")` | no match, `Any` | `str \| list[str] \| None` |
| `download_media(message, in_memory=True)` | `BinaryIO \| list[BinaryIO]` | `BinaryIO \| list[BinaryIO] \| None` |
| `download_media(message, "downloads/", True)` | no match | `BinaryIO \| list[BinaryIO] \| None` |
| `download_media(message, block=False)` | `None` | unchanged |
| `download_media(message, "downloads/", True, False)` | no match | `None` |
| `download_media(message, in_memory=flag)`, `flag: bool` | no match | `str \| BinaryIO \| list[str] \| list[BinaryIO] \| None` |

The `| None` on the two blocking rows is not new behaviour — a download that fails, or one
stopped with `stop_transmission()`, has always resolved to `None`, and the docstring has
always said so. Only the overloads refused to.

The last row is why there are five overloads rather than three. An argument a checker
cannot pin to a literal has no single shape, so it falls to a catch-all that repeats the
implementation's own return union. That overload has to come last, and the `block=False`
one above it has to require `block` rather than default it — an omitted argument is not
checked against its default, so a defaulted `block: Literal[False]` would swallow every
call passing a plain `bool` and tell it the result is `None` while at runtime it blocks
and returns a path.

Six more methods get two overloads each, keyed on the id argument, the way `get_messages()`
already does it:

| method | single id | iterable of ids |
| --- | --- | --- |
| `get_users` | `User` | `list[User]` |
| `get_stories` | `Story \| None` | `list[Story]` |
| `forward_messages` | `Message \| None` | `list[Message]` |
| `delete_contacts` | `User \| None` | `list[User] \| None` |
| `get_forum_topics_by_id` | `ForumTopic` | `list[ForumTopic]` |
| `get_direct_messages_topics_by_id` | `DirectMessagesTopic \| None` | `list[DirectMessagesTopic]` |

### 2. The `None` that 72 annotations refused to admit

Writing those overloads meant reading the bodies, and the bodies kept ending in a `None`
nothing declared. So the same question was asked of every public method: can this return
`None`, and does it say so? Seventy-two annotations gained it. They fall into a handful of
recurring shapes:

- `return next(iter(...), None)` — the default is `None` and the annotation said otherwise;
- `parse_messages()` reading `r.updates`, where five of the seven `Updates` constructors
  carry no `updates` vector at all, so a successful answer can parse to nothing;
- uploads that `return None` when `save_file()` is stopped mid-transfer;
- bound methods on `Message` / `Story` / `Chat` / `Gift` that hand a nullable send result
  straight back, having been annotated as if it could not be;
- `full_name` properties that fall back to `None`.

Four annotations moved the other way, because they claimed a `None` that never happens:

| method | before | after |
| --- | --- | --- |
| `buy_gift_upgrade` | `Message \| None` | `bool` |
| `stream_media` | `str \| BinaryIO \| None` | `AsyncIterator[bytes]` |
| `get_chat_photos` | `Optional[AsyncGenerator[...]]` | `AsyncIterator[Photo \| Animation]` |
| `get_chat_audios` | `Optional[AsyncGenerator[Audio, None]]` | `AsyncIterator[Audio]` |

`buy_gift_upgrade()` ends in `return True` and its docstring already said ``bool`` — the
mirror image of `get_bot_default_privileges()`, fixed in the same sweep. The other three
are `async def`s containing `yield`, so they were never returning what they said at all.

### 3. One shape for every `Returns:` block that mentions `None`

132 blocks now read the same way, the way `delete_contacts()` already did:

```
<type> | ``None``: On success, <success case> is returned, otherwise, <condition>, None is returned.
```

This is not cosmetic. A uniform block can be checked mechanically against the annotation
next to it; free-form prose cannot. Walking the AST over `pyrogram/methods` and
`pyrogram/types` and comparing the two in both directions:

| | before | after |
| --- | --- | --- |
| annotation admits `None`, docs silent | 31 | 0 |
| docs promise `None`, annotation refuses | 1 | 0 |

(45 methods still carry no return annotation at all, down from 47. That is a separate,
mechanical change and is deliberately not in this PR.)

### 4. `AsyncGenerator[X, None]` → `AsyncIterator[X]`

29 annotations. The second parameter of `AsyncGenerator` is the *send* type — what
`gen.asend(...)` accepts — and it is `None` in every one of them because nothing ever
sends. It carries no information, and it reads as nullability to anything scanning for
`None`. `AsyncIterator[X]` says the same thing without the dead parameter.

## The one behaviour change

`get_forum_topics_by_id.py`:

```diff
-        return topics if is_iterable else topics[0] if topics else None
+        return topics if is_iterable else topics[0]
```

The `None` branch is unreachable. `messages.getForumTopicsByID` returns one entry per
requested id and never fewer: an id that does not exist comes back as `forumTopicDeleted`,
and an id below 1 is refused outright with `TOPICS_EMPTY`.

```python
GetForumTopicsByID(peer=peer, topics=[999999])
# -> messages.ForumTopics(topics=[raw.types.ForumTopicDeleted(id=999999)], ...)
```

Keeping it would have forced every single-id caller into a `None` check that can never
fire. Worth flagging, though: `Message._parse()` catches `(ChannelPrivate, ChannelForumMissing)`
and `(ChannelPrivate, ChatAdminRequired)`, but not `IndexError` — so if a future TL change
ever does return an empty vector here, this surfaces as an `IndexError` rather than a
`None`. That seemed the better failure: loud, and at the right place.

Two other lines show up in the diff outside docstrings and annotations, both in
`save_file.py`, and both are no-ops: a bare `return` spelled `return None`, and an explicit
`return None` added as the last statement of the function, where control already fell off
the end.

## Why

Before this, callers had to `cast()` or run an `isinstance` check that can never fail on
every single-id call site, and `download_media(message)` — the first example in its own
docstring — did not type-check at all. In the other direction, 72 methods could hand back
a `None` that no checker would warn about, which is the failure mode that actually reaches
production.

## Notes

- **mypy cost.** Against a clean `upstream/dev` checkout with identical flags: 8361 errors
  before, 8410 after. Of the 146 new ones, **126 are the single `save_file()` → `InputFile`
  chain** — `save_file()` genuinely returns `Optional[InputFile | InputFileBig]`, and the
  call sites do not check it. Those errors are not introduced by this PR; they were always
  there, hidden behind an annotation that promised too much. The remaining 20 are 14
  repeats of the pre-existing *erased type of self* complaint (now multiplied by the new
  overload stubs) plus 6 genuine pre-existing defects the honest annotations surface, all
  left alone here. 97 errors disappear, including every *No overload variant of
  `download_media` matches* and *signatures 1 and 2/3 overlap*.
- **`get_users` overlap.** `str` is itself an iterable of `str`, so a username matches both
  overloads. Ordering the single-user one first resolves it the way the body does; the pair
  still reads as overlapping to a checker, hence the one targeted
  `type: ignore[overload-overlap]` with a comment.
- **`forward_messages` parameters.** Eleven parameters default to `None` under a
  non-optional annotation. An overload cannot be more permissive than the implementation it
  belongs to — mypy answers with *Overloaded function implementation does not accept all
  possible parameters of signature 1* — so those eleven had to be wrapped in `Optional[...]`
  first. That is its own commit (`bd9baca6`) and can be reviewed or dropped separately; it
  matches how 487 parameters across 115 method modules are already annotated. The same
  problem elsewhere in the library is left alone.
- The commits are ordered so each one is a single, reviewable idea, and the mechanical
  sweeps (`Returns:` shape, `AsyncIterator`) are last and separate from the judgement calls.

## How to test

```python
from pyrogram import Client, types


async def probe(client: Client, message: types.Message) -> None:
    reveal_type(await client.download_media(message))            # str | list[str] | None
    reveal_type(await client.get_users(123))                     # User
    reveal_type(await client.get_users([123, 456]))              # list[User]
    reveal_type(await client.forward_messages(1, 2, 3))          # Message | None
    reveal_type(await client.forward_messages(1, 2, [3, 4]))     # list[Message]
    reveal_type(await client.get_forum_topics_by_id(1, 2))       # ForumTopic
    reveal_type(await client.get_forum_topics_by_id(1, [2, 3]))  # list[ForumTopic]
    reveal_type(await client.buy_gift_upgrade(123, "hash", 1))   # bool
    reveal_type(client.stream_media(message))                    # AsyncIterator[bytes]
```

`mypy` reports no errors on that file and reveals the types in the comments.
`pytest tests` passes (48). Both shapes of `get_users`, `forward_messages`, `get_stories`
and all three `download_media` forms were run against a real account to confirm the
annotations match the runtime behaviour, as were the `TOPICS_EMPTY` and `forumTopicDeleted`
responses quoted above.
