### PR TITLE
fix: require the parameters that cannot default to None

### DIFF
--- a/pyrogram/methods/bots/get_game_high_scores.py
+++ b/pyrogram/methods/bots/get_game_high_scores.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List, Optional
+from typing import Union, List
 
 import pyrogram
 from pyrogram import raw
@@ -28,7 +28,7 @@ class GetGameHighScores:
         self: "pyrogram.Client",
         user_id: Union[int, str],
         chat_id: Union[int, str],
-        message_id: Optional[int] = None
+        message_id: int
     ) -> List["types.GameHighScore"]:
         """Get data for high score tables.
 
@@ -40,15 +40,13 @@ class GetGameHighScores:
                 For your personal cloud (Saved Messages) you can simply use "me" or "self".
                 For a contact that exists in your Telegram address book you can use his phone number (str).
 
-            chat_id (``int`` | ``str``, *optional*):
+            chat_id (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the target chat.
                 For your personal cloud (Saved Messages) you can simply use "me" or "self".
                 For a contact that exists in your Telegram address book you can use his phone number (str).
-                Required if inline_message_id is not specified.
 
-            message_id (``int``, *optional*):
+            message_id (``int``):
                 Identifier of the sent message.
-                Required if inline_message_id is not specified.
 
         Returns:
             List of :obj:`~pyrogram.types.GameHighScore`: On success.

--- a/pyrogram/methods/bots/set_game_score.py
+++ b/pyrogram/methods/bots/set_game_score.py
@@ -26,13 +26,12 @@ from pyrogram import types
 class SetGameScore:
     async def set_game_score(
         self: "pyrogram.Client",
+        chat_id: Union[int, str],
+        message_id: int,
         user_id: Union[int, str],
         score: int,
         force: Optional[bool] = None,
-        disable_edit_message: Optional[bool] = None,
-        *,
-        chat_id: Union[int, str],
-        message_id: int
+        disable_edit_message: Optional[bool] = None
     ) -> Union["types.Message", bool]:
         # inline_message_id: str = None):  TODO Add inline_message_id
         """Set the score of the specified user in a game.
@@ -40,6 +39,14 @@ class SetGameScore:
         .. include:: /_includes/usable-by/bots.rst
 
         Parameters:
+            chat_id (``int`` | ``str``):
+                Unique identifier (int) or username (str) of the target chat.
+                For your personal cloud (Saved Messages) you can simply use "me" or "self".
+                For a contact that exists in your Telegram address book you can use his phone number (str).
+
+            message_id (``int``):
+                Identifier of the sent message.
+
             user_id (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the target chat.
                 For your personal cloud (Saved Messages) you can simply use "me" or "self".
@@ -55,14 +62,6 @@ class SetGameScore:
             disable_edit_message (``bool``, *optional*):
                 Pass True, if the game message should not be automatically edited to include the current scoreboard.
 
-            chat_id (``int`` | ``str``):
-                Unique identifier (int) or username (str) of the target chat.
-                For your personal cloud (Saved Messages) you can simply use "me" or "self".
-                For a contact that exists in your Telegram address book you can use his phone number (str).
-
-            message_id (``int``):
-                Identifier of the sent message.
-
         Returns:
             :obj:`~pyrogram.types.Message` | ``bool``: On success, if the message was sent by the bot, the edited
             message is returned, True otherwise.
@@ -71,10 +70,10 @@ class SetGameScore:
             .. code-block:: python
 
                 # Set new score
-                await app.set_game_score(user_id, 1000, chat_id=chat_id, message_id=message_id)
+                await app.set_game_score(chat_id, message_id, user_id, 1000)
 
                 # Force set new score
-                await app.set_game_score(user_id, 25, force=True, chat_id=chat_id, message_id=message_id)
+                await app.set_game_score(chat_id, message_id, user_id, 25, force=True)
         """
         r = await self.invoke(
             raw.functions.messages.SetGameScore(

--- a/pyrogram/methods/bots/set_game_score.py
+++ b/pyrogram/methods/bots/set_game_score.py
@@ -30,8 +30,9 @@ class SetGameScore:
         score: int,
         force: Optional[bool] = None,
         disable_edit_message: Optional[bool] = None,
-        chat_id: Optional[Union[int, str]] = None,
-        message_id: Optional[int] = None
+        *,
+        chat_id: Union[int, str],
+        message_id: int
     ) -> Union["types.Message", bool]:
         # inline_message_id: str = None):  TODO Add inline_message_id
         """Set the score of the specified user in a game.
@@ -54,15 +55,13 @@ class SetGameScore:
             disable_edit_message (``bool``, *optional*):
                 Pass True, if the game message should not be automatically edited to include the current scoreboard.
 
-            chat_id (``int`` | ``str``, *optional*):
+            chat_id (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the target chat.
                 For your personal cloud (Saved Messages) you can simply use "me" or "self".
                 For a contact that exists in your Telegram address book you can use his phone number (str).
-                Required if inline_message_id is not specified.
 
-            message_id (``int``, *optional*):
+            message_id (``int``):
                 Identifier of the sent message.
-                Required if inline_message_id is not specified.
 
         Returns:
             :obj:`~pyrogram.types.Message` | ``bool``: On success, if the message was sent by the bot, the edited
@@ -72,10 +71,10 @@ class SetGameScore:
             .. code-block:: python
 
                 # Set new score
-                await app.set_game_score(user_id, 1000)
+                await app.set_game_score(user_id, 1000, chat_id=chat_id, message_id=message_id)
 
                 # Force set new score
-                await app.set_game_score(user_id, 25, force=True)
+                await app.set_game_score(user_id, 25, force=True, chat_id=chat_id, message_id=message_id)
         """
         r = await self.invoke(
             raw.functions.messages.SetGameScore(

--- a/pyrogram/methods/messages/set_direct_messages_chat_topic_is_marked_as_unread.py
+++ b/pyrogram/methods/messages/set_direct_messages_chat_topic_is_marked_as_unread.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import Optional, Union
+from typing import Union
 
 import pyrogram
 from pyrogram import raw
@@ -27,7 +27,7 @@ class SetDirectMessagesChatTopicIsMarkedAsUnread:
     async def set_direct_messages_chat_topic_is_marked_as_unread(
         self: "pyrogram.Client",
         chat_id: Union[int, str],
-        topic_id: Optional[int] = None,
+        topic_id: int,
         is_marked_as_unread: bool = True
     ) -> int:
         """Change the marked as unread state of the topic in a channel direct messages chat administered by the current user.

--- a/pyrogram/types/messages_and_media/media_area.py
+++ b/pyrogram/types/messages_and_media/media_area.py
@@ -151,7 +151,7 @@ class MediaArea(Object):
     async def _parse(
         client: "pyrogram.Client",
         area: "raw.base.MediaArea",
-        chats: Optional[dict] = None
+        chats: dict
     ) -> "MediaArea":
         sender_chat = None
         message_id = None

--- a/pyrogram/types/messages_and_media/media_area.py
+++ b/pyrogram/types/messages_and_media/media_area.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 import pyrogram
 from pyrogram import enums, raw, types
@@ -151,7 +151,7 @@ class MediaArea(Object):
     async def _parse(
         client: "pyrogram.Client",
         area: "raw.base.MediaArea",
-        chats: dict
+        chats: Dict[int, "raw.base.Chat"]
     ) -> "MediaArea":
         sender_chat = None
         message_id = None

--- a/pyrogram/types/user_and_chats/business_weekly_open.py
+++ b/pyrogram/types/user_and_chats/business_weekly_open.py
@@ -16,8 +16,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
-
 from pyrogram import raw
 from ..object import Object
 
@@ -44,7 +42,7 @@ class BusinessWeeklyOpen(Object):
         self.end_minute = end_minute
 
     @staticmethod
-    def _parse(weekly_open: Optional["raw.types.BusinessWeeklyOpen"] = None) -> "BusinessWeeklyOpen":
+    def _parse(weekly_open: "raw.types.BusinessWeeklyOpen") -> "BusinessWeeklyOpen":
         return BusinessWeeklyOpen(
             start_minute=weekly_open.start_minute,
             end_minute=weekly_open.end_minute,

--- a/pyrogram/types/user_and_chats/chat_admin_with_invite_links.py
+++ b/pyrogram/types/user_and_chats/chat_admin_with_invite_links.py
@@ -54,7 +54,7 @@ class ChatAdminWithInviteLinks(Object):
     def _parse(
         client: "pyrogram.Client",
         admin: "raw.types.ChatAdminWithInvites",
-        users: Optional[Dict[int, "raw.types.User"]] = None
+        users: Dict[int, "raw.types.User"]
     ) -> "ChatAdminWithInviteLinks":
         return ChatAdminWithInviteLinks(
             admin=types.User._parse(client, users[admin.admin_id]),


### PR DESCRIPTION
Closes #344.

## What

Seven parameters that default to `None` and are then used unconditionally now have no default.

| method | parameter | why it cannot default |
| --- | --- | --- |
| `set_game_score()` | `chat_id`, `message_id` | go to `peer` and `id` of `messages.setGameScore`, both required in the schema |
| `get_game_high_scores()` | `message_id` | goes to `id` of `messages.getGameHighScores`, required in the schema |
| `set_direct_messages_chat_topic_is_marked_as_unread()` | `topic_id` | goes to `peer` of `messages.markDialogUnread` |
| `MediaArea._parse()` | `chats` | `chats.get(...)` |
| `BusinessWeeklyOpen._parse()` | `weekly_open` | `weekly_open.start_minute` |
| `ChatAdminWithInviteLinks._parse()` | `users` | `users[admin.admin_id]` |

`set_game_score()` takes `chat_id` and `message_id` first now, ahead of the optional parameters, so the signature carries no keyword-only marker. Existing positional calls fail loudly rather than shift meaning: `set_game_score(user_id, 1000)` used to bind `user_id` and `score` and now reports `missing a required argument: 'user_id'`. Its two docstring examples were calls that built a request with `peer=None`, so they are fixed here too.

`chat_id` of `get_game_high_scores()` was already required by the signature but documented as optional; the docstring now matches.

The three `_parse()` helpers are private and each has exactly one caller inside the library — `get_chat_admins_with_invite_links.py`, `business_working_hours.py`, `story.py` — and all three pass the argument, so the default was unreachable. `MediaArea._parse()` now also spells that argument out as `Dict[int, "raw.base.Chat"]`, the annotation its caller `Story._parse()` already uses for the very same dict.

## Why

These were not optional parameters, they were parameters whose absence crashes. `set_game_score(user_id, 1000)` reached `messages.SetGameScore(peer=None, id=None, ...)` and died in serialisation with `AttributeError: 'NoneType' object has no attribute 'write'`, before anything left the client.

The optionality comes from the Bot API, where `chat_id` and `message_id` may be omitted in favour of `inline_message_id` — which needs `messages.setInlineGameScore` / `messages.getInlineGameHighScores`, a separate pair of requests that this library does not call yet. The `TODO`s about it are left in place. Until they are implemented, the signature should not promise the call.

## Notes

This is independent of #341 and #343 and can be merged in any order, but it edits the same seven lines that #343 edits, so whichever lands second needs a trivial rebase. Removing these defaults also removes seven parameters from #343's sweep.

## How to test

```python
import inspect

from pyrogram import Client

inspect.signature(Client.set_game_score).bind(client, user_id, 1000)
# TypeError: missing a required argument: 'user_id'
inspect.signature(Client.get_game_high_scores).bind(client, user_id, chat_id)
# TypeError: missing a required argument: 'message_id'
```

Both of those used to bind and then fail inside serialisation. `pytest tests` passes, and no call site inside the library relies on any of the removed defaults.

