### PR TITLE
fix(file-id): decode photo file ids minted from minor 32 onwards

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -1144,7 +1144,10 @@ class Client(Methods):
                 location = raw.types.InputPeerPhotoFileLocation(
                     peer=peer,
                     photo_id=file_id.media_id,
-                    big=file_id.thumbnail_source == ThumbnailSource.CHAT_PHOTO_BIG
+                    big=file_id.thumbnail_source in (
+                        ThumbnailSource.CHAT_PHOTO_BIG,
+                        ThumbnailSource.CHAT_PHOTO_BIG_LEGACY
+                    )
                 )
             elif file_type == FileType.PHOTO:
                 location = raw.types.InputPhotoFileLocation(

--- a/pyrogram/file_id.py
+++ b/pyrogram/file_id.py
@@ -19,9 +19,10 @@
 import base64
 import logging
 import struct
+from dataclasses import dataclass, replace
 from enum import IntEnum
 from io import BytesIO
-from typing import List, Optional
+from typing import Final, List, Optional
 
 from pyrogram.raw.core import Bytes, String
 
@@ -133,12 +134,34 @@ class FileType(IntEnum):
 
 
 class ThumbnailSource(IntEnum):
-    """Known thumbnail sources"""
+    """Known thumbnail sources.
+
+    TDLib mints the file ids, so its ``PhotoSizeSource`` is the authority on the values:
+    https://github.com/tdlib/td/blob/master/td/telegram/PhotoSizeSource.h
+    """
     LEGACY = 0
     THUMBNAIL = 1
     CHAT_PHOTO_SMALL = 2  # DialogPhotoSmall
     CHAT_PHOTO_BIG = 3  # DialogPhotoBig
     STICKER_SET_THUMBNAIL = 4
+    FULL_LEGACY = 5
+    CHAT_PHOTO_SMALL_LEGACY = 6  # DialogPhotoSmallLegacy
+    CHAT_PHOTO_BIG_LEGACY = 7  # DialogPhotoBigLegacy
+    STICKER_SET_THUMBNAIL_LEGACY = 8
+    STICKER_SET_THUMBNAIL_VERSION = 9
+
+
+# NOTE: TDLib's `Version::RemovePhotoVolumeAndLocalId` — the minor version from which photo file ids
+#       carry neither `volume_id` nor `local_id`, the sources that still need them having become
+#       values 5 to 9 above. Reading a current file id against the older layout takes the source tag
+#       for `volume_id` and part of the tail for the source:
+#
+#         FileId.decode("AgACAgIAAxkBAAIENGfeY4AfRquwTL2LpDrzqvFMVNt_AAIG9DEbXX3wSq3o"
+#                       "I7t_PqQGAQADAgADbQADNgQ")
+#         # -> ValueError: Unknown thumbnail_source 109 of file_id AgACAgI...
+#
+#       https://github.com/tdlib/td/blob/master/td/telegram/files/FileLocation.hpp
+NO_VOLUME_AND_LOCAL_ID_MINOR: Final[int] = 32
 
 
 # Photo-like file ids are longer and contain extra info, the rest are all documents
@@ -150,6 +173,138 @@ DOCUMENT_TYPES = set(FileType) - PHOTO_TYPES
 # encode extra information about web url and file reference existence as flag inside the 4 bytes allocated for the field
 WEB_LOCATION_FLAG = 1 << 24
 FILE_REFERENCE_FLAG = 1 << 25
+
+
+@dataclass(frozen=True)
+class PhotoTail:
+    """What a photo file id carries after its source tag, one field per `FileId` argument.
+
+    Which of them are filled is decided by the source; the rest keep the default `FileId` gives them.
+    """
+    volume_id: Optional[int] = None
+    local_id: Optional[int] = None
+    secret: Optional[int] = None
+    thumbnail_file_type: Optional[int] = None
+    thumbnail_size: str = ""
+    chat_id: Optional[int] = None
+    chat_access_hash: Optional[int] = None
+    sticker_set_id: Optional[int] = None
+    sticker_set_access_hash: Optional[int] = None
+    sticker_set_version: Optional[int] = None
+
+
+def read_photo_tail(buffer: BytesIO, *, thumbnail_source: ThumbnailSource) -> PhotoTail:
+    """Each layout is the matching `store()` in TDLib's `PhotoSizeSource.hpp` read backwards.
+
+    https://github.com/tdlib/td/blob/master/td/telegram/PhotoSizeSource.hpp
+    """
+    if thumbnail_source == ThumbnailSource.LEGACY:
+        secret, = struct.unpack("<q", buffer.read(8))
+
+        return PhotoTail(secret=secret)
+
+    # NOTE: `thumbnail_size` is the `type` of the `PhotoSize` the file id points at — one letter,
+    #       whose character code the file id stores as an int32 while
+    #       `inputPhotoFileLocation.thumb_size` takes a `string`. It is a `str` from here on:
+    #       `chr()` in, `ord()` back out in `write_photo_tail()`, `get_file()` passes it through.
+    #
+    #       What the letters mean: https://core.telegram.org/api/files#image-thumbnail-types, and
+    #       the same table with the order Telegram Desktop picks them in:
+    #       https://github.com/telegramdesktop/tdesktop/blob/8e18cb71103d83d7d98994ff27f0a2bca55c489c/Telegram/SourceFiles/data/data_session.cpp#L102-L114
+    if thumbnail_source == ThumbnailSource.THUMBNAIL:
+        thumbnail_file_type, thumbnail_size = struct.unpack("<ii", buffer.read(8))
+
+        return PhotoTail(thumbnail_file_type=thumbnail_file_type, thumbnail_size=chr(thumbnail_size))
+
+    if thumbnail_source in (ThumbnailSource.CHAT_PHOTO_SMALL, ThumbnailSource.CHAT_PHOTO_BIG):
+        chat_id, chat_access_hash = struct.unpack("<qq", buffer.read(16))
+
+        return PhotoTail(chat_id=chat_id, chat_access_hash=chat_access_hash)
+
+    if thumbnail_source == ThumbnailSource.STICKER_SET_THUMBNAIL:
+        sticker_set_id, sticker_set_access_hash = struct.unpack("<qq", buffer.read(16))
+
+        return PhotoTail(sticker_set_id=sticker_set_id, sticker_set_access_hash=sticker_set_access_hash)
+
+    # NOTE: `secret` sits between the other two, where `inputPhotoLegacyFileLocation` lists them as
+    #       `volume_id local_id secret`. The file id follows `FullLegacy::store`, not the schema.
+    if thumbnail_source == ThumbnailSource.FULL_LEGACY:
+        volume_id, secret, local_id = struct.unpack("<qqi", buffer.read(20))
+
+        return PhotoTail(volume_id=volume_id, secret=secret, local_id=local_id)
+
+    if thumbnail_source in (ThumbnailSource.CHAT_PHOTO_SMALL_LEGACY, ThumbnailSource.CHAT_PHOTO_BIG_LEGACY):
+        chat_id, chat_access_hash, volume_id, local_id = struct.unpack("<qqqi", buffer.read(28))
+
+        return PhotoTail(
+            chat_id=chat_id,
+            chat_access_hash=chat_access_hash,
+            volume_id=volume_id,
+            local_id=local_id
+        )
+
+    if thumbnail_source == ThumbnailSource.STICKER_SET_THUMBNAIL_LEGACY:
+        sticker_set_id, sticker_set_access_hash, volume_id, local_id = struct.unpack("<qqqi", buffer.read(28))
+
+        return PhotoTail(
+            sticker_set_id=sticker_set_id,
+            sticker_set_access_hash=sticker_set_access_hash,
+            volume_id=volume_id,
+            local_id=local_id
+        )
+
+    if thumbnail_source == ThumbnailSource.STICKER_SET_THUMBNAIL_VERSION:
+        sticker_set_id, sticker_set_access_hash, sticker_set_version = struct.unpack("<qqi", buffer.read(20))
+
+        return PhotoTail(
+            sticker_set_id=sticker_set_id,
+            sticker_set_access_hash=sticker_set_access_hash,
+            sticker_set_version=sticker_set_version
+        )
+
+    msg = f"No layout for thumbnail_source: {thumbnail_source!r}"
+    raise ValueError(msg)
+
+
+def write_photo_tail(file_id: "FileId") -> bytes:
+    """The counterpart of `read_photo_tail()` — same layout per source, same order."""
+    if file_id.thumbnail_source == ThumbnailSource.LEGACY:
+        return struct.pack("<q", file_id.secret)
+
+    if file_id.thumbnail_source == ThumbnailSource.THUMBNAIL:
+        return struct.pack("<ii", file_id.thumbnail_file_type, ord(file_id.thumbnail_size))
+
+    if file_id.thumbnail_source in (ThumbnailSource.CHAT_PHOTO_SMALL, ThumbnailSource.CHAT_PHOTO_BIG):
+        return struct.pack("<qq", file_id.chat_id, file_id.chat_access_hash)
+
+    if file_id.thumbnail_source == ThumbnailSource.STICKER_SET_THUMBNAIL:
+        return struct.pack("<qq", file_id.sticker_set_id, file_id.sticker_set_access_hash)
+
+    if file_id.thumbnail_source == ThumbnailSource.FULL_LEGACY:
+        return struct.pack("<qqi", file_id.volume_id, file_id.secret, file_id.local_id)
+
+    if file_id.thumbnail_source in (ThumbnailSource.CHAT_PHOTO_SMALL_LEGACY, ThumbnailSource.CHAT_PHOTO_BIG_LEGACY):
+        return struct.pack("<qqqi", file_id.chat_id, file_id.chat_access_hash, file_id.volume_id, file_id.local_id)
+
+    if file_id.thumbnail_source == ThumbnailSource.STICKER_SET_THUMBNAIL_LEGACY:
+        return struct.pack(
+            "<qqqi",
+            file_id.sticker_set_id,
+            file_id.sticker_set_access_hash,
+            file_id.volume_id,
+            file_id.local_id
+        )
+
+    if file_id.thumbnail_source == ThumbnailSource.STICKER_SET_THUMBNAIL_VERSION:
+        return struct.pack(
+            "<qqi",
+            file_id.sticker_set_id,
+            file_id.sticker_set_access_hash,
+            file_id.sticker_set_version
+        )
+
+    msg = f"No layout for thumbnail_source: {file_id.thumbnail_source!r}"
+    raise ValueError(msg)
 
 
 class FileId:
@@ -175,7 +330,8 @@ class FileId:
         chat_id: Optional[int] = None,
         chat_access_hash: Optional[int] = None,
         sticker_set_id: Optional[int] = None,
-        sticker_set_access_hash: Optional[int] = None
+        sticker_set_access_hash: Optional[int] = None,
+        sticker_set_version: Optional[int] = None
     ):
         self.major = major
         self.minor = minor
@@ -195,6 +351,7 @@ class FileId:
         self.chat_access_hash = chat_access_hash
         self.sticker_set_id = sticker_set_id
         self.sticker_set_access_hash = sticker_set_access_hash
+        self.sticker_set_version = sticker_set_version
 
     @staticmethod
     def decode(file_id: str):
@@ -246,7 +403,9 @@ class FileId:
         media_id, access_hash = struct.unpack("<qq", buffer.read(16))
 
         if file_type in PHOTO_TYPES:
-            volume_id, = struct.unpack("<q", buffer.read(8))
+            has_volume_and_local_id = minor < NO_VOLUME_AND_LOCAL_ID_MINOR
+            volume_id = struct.unpack("<q", buffer.read(8))[0] if has_volume_and_local_id else None
+
             thumbnail_source, = (0,) if major < 4 else struct.unpack("<i", buffer.read(4))
 
             try:
@@ -254,77 +413,33 @@ class FileId:
             except ValueError:
                 raise ValueError(f"Unknown thumbnail_source {thumbnail_source} of file_id {file_id}")
 
-            if thumbnail_source == ThumbnailSource.LEGACY:
-                secret, local_id = struct.unpack("<qi", buffer.read(12))
+            tail = read_photo_tail(buffer, thumbnail_source=thumbnail_source)
 
-                return FileId(
-                    major=major,
-                    minor=minor,
-                    file_type=file_type,
-                    dc_id=dc_id,
-                    file_reference=file_reference,
-                    media_id=media_id,
-                    access_hash=access_hash,
-                    volume_id=volume_id,
-                    thumbnail_source=thumbnail_source,
-                    secret=secret,
-                    local_id=local_id
-                )
+            # Before minor 32 every source shared one layout, with `local_id` last.
+            if has_volume_and_local_id:
+                local_id, = struct.unpack("<i", buffer.read(4))
+                tail = replace(tail, volume_id=volume_id, local_id=local_id)
 
-            if thumbnail_source == ThumbnailSource.THUMBNAIL:
-                thumbnail_file_type, thumbnail_size, local_id = struct.unpack("<iii", buffer.read(12))
-                thumbnail_size = chr(thumbnail_size)
-
-                return FileId(
-                    major=major,
-                    minor=minor,
-                    file_type=file_type,
-                    dc_id=dc_id,
-                    file_reference=file_reference,
-                    media_id=media_id,
-                    access_hash=access_hash,
-                    volume_id=volume_id,
-                    thumbnail_source=thumbnail_source,
-                    thumbnail_file_type=thumbnail_file_type,
-                    thumbnail_size=thumbnail_size,
-                    local_id=local_id
-                )
-
-            if thumbnail_source in (ThumbnailSource.CHAT_PHOTO_SMALL, ThumbnailSource.CHAT_PHOTO_BIG):
-                chat_id, chat_access_hash, local_id = struct.unpack("<qqi", buffer.read(20))
-
-                return FileId(
-                    major=major,
-                    minor=minor,
-                    file_type=file_type,
-                    dc_id=dc_id,
-                    file_reference=file_reference,
-                    media_id=media_id,
-                    access_hash=access_hash,
-                    volume_id=volume_id,
-                    thumbnail_source=thumbnail_source,
-                    chat_id=chat_id,
-                    chat_access_hash=chat_access_hash,
-                    local_id=local_id
-                )
-
-            if thumbnail_source == ThumbnailSource.STICKER_SET_THUMBNAIL:
-                sticker_set_id, sticker_set_access_hash, local_id = struct.unpack("<qqi", buffer.read(20))
-
-                return FileId(
-                    major=major,
-                    minor=minor,
-                    file_type=file_type,
-                    dc_id=dc_id,
-                    file_reference=file_reference,
-                    media_id=media_id,
-                    access_hash=access_hash,
-                    volume_id=volume_id,
-                    thumbnail_source=thumbnail_source,
-                    sticker_set_id=sticker_set_id,
-                    sticker_set_access_hash=sticker_set_access_hash,
-                    local_id=local_id
-                )
+            return FileId(
+                major=major,
+                minor=minor,
+                file_type=file_type,
+                dc_id=dc_id,
+                file_reference=file_reference,
+                media_id=media_id,
+                access_hash=access_hash,
+                thumbnail_source=thumbnail_source,
+                volume_id=tail.volume_id,
+                local_id=tail.local_id,
+                secret=tail.secret,
+                thumbnail_file_type=tail.thumbnail_file_type,
+                thumbnail_size=tail.thumbnail_size,
+                chat_id=tail.chat_id,
+                chat_access_hash=tail.chat_access_hash,
+                sticker_set_id=tail.sticker_set_id,
+                sticker_set_access_hash=tail.sticker_set_access_hash,
+                sticker_set_version=tail.sticker_set_version
+            )
 
         if file_type in DOCUMENT_TYPES:
             return FileId(
@@ -362,34 +477,18 @@ class FileId:
         buffer.write(struct.pack("<qq", self.media_id, self.access_hash))
 
         if self.file_type in PHOTO_TYPES:
-            buffer.write(struct.pack("<q", self.volume_id))
+            has_volume_and_local_id = minor < NO_VOLUME_AND_LOCAL_ID_MINOR
+
+            if has_volume_and_local_id:
+                buffer.write(struct.pack("<q", self.volume_id))
 
             if major >= 4:
                 buffer.write(struct.pack("<i", self.thumbnail_source))
 
-            if self.thumbnail_source == ThumbnailSource.LEGACY:
-                buffer.write(struct.pack("<qi", self.secret, self.local_id))
-            elif self.thumbnail_source == ThumbnailSource.THUMBNAIL:
-                buffer.write(struct.pack(
-                    "<iii",
-                    self.thumbnail_file_type,
-                    ord(self.thumbnail_size),
-                    self.local_id
-                ))
-            elif self.thumbnail_source in (ThumbnailSource.CHAT_PHOTO_SMALL, ThumbnailSource.CHAT_PHOTO_BIG):
-                buffer.write(struct.pack(
-                    "<qqi",
-                    self.chat_id,
-                    self.chat_access_hash,
-                    self.local_id
-                ))
-            elif self.thumbnail_source == ThumbnailSource.STICKER_SET_THUMBNAIL:
-                buffer.write(struct.pack(
-                    "<qqi",
-                    self.sticker_set_id,
-                    self.sticker_set_access_hash,
-                    self.local_id
-                ))
+            buffer.write(write_photo_tail(self))
+
+            if has_volume_and_local_id:
+                buffer.write(struct.pack("<i", self.local_id))
         elif file_type in DOCUMENT_TYPES:
             buffer.write(struct.pack("<ii", minor, major))
 

--- a/tests/test_file_id.py
+++ b/tests/test_file_id.py
@@ -16,9 +16,54 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+import struct
+
 import pytest
 
-from pyrogram.file_id import FileId, FileUniqueId, FileType, FileUniqueType
+from pyrogram.file_id import (
+    FILE_REFERENCE_FLAG,
+    FileId,
+    FileUniqueId,
+    FileType,
+    FileUniqueType,
+    ThumbnailSource,
+    b64_encode,
+    rle_encode,
+)
+from pyrogram.raw.core import Bytes
+
+# Arbitrary, only has to survive the round trip.
+DC_ID = 2
+MEDIA_ID = 5399953792058913798
+ACCESS_HASH = 478576178729576621
+FILE_REFERENCE = b"\x01\x02\x03\x04"
+
+VOLUME_ID = 1234567890123456789
+LOCAL_ID = 42
+SECRET = 987654321098765432
+CHAT_ID = -1001234567890
+CHAT_ACCESS_HASH = 1122334455667788990
+STICKER_SET_ID = 2233445566778899001
+STICKER_SET_ACCESS_HASH = 3344556677889900112
+STICKER_SET_VERSION = 7
+
+
+def photo_file_id(*, minor: int, thumbnail_source: int, tail: bytes) -> str:
+    """Assemble a photo file id byte for byte the way TDLib's `FullRemoteFileLocation::store` does.
+
+    Built by hand rather than through `FileId.encode()`, so that what a case asserts is the layout
+    TDLib writes and not merely that our own two halves agree with each other.
+    """
+    payload = (
+        struct.pack("<ii", FileType.PHOTO | FILE_REFERENCE_FLAG, DC_ID)
+        + Bytes(FILE_REFERENCE)
+        + struct.pack("<qq", MEDIA_ID, ACCESS_HASH)
+        + struct.pack("<i", thumbnail_source)
+        + tail
+        + struct.pack("<bb", minor, 4)
+    )
+
+    return b64_encode(rle_encode(payload))
 
 
 def check(file_id: str, expected_file_type: FileType):
@@ -176,6 +221,149 @@ def test_unknown_thumbnail_source():
 
     with pytest.raises(ValueError, match=r"Unknown thumbnail_source \d+ of file_id \w+"):
         check(unknown, FileType.THUMBNAIL)
+
+
+def test_photo_from_a_current_client():
+    """The file id from #178, minted at minor 54, which `decode()` used to reject.
+
+    Twelve bytes trail `access_hash`: `01000000 02000000 6d000000`. Read against the pre-32 layout
+    the first eight become `volume_id` and `6d000000` becomes the source, hence the reported
+    `ValueError: Unknown thumbnail_source 109`. Read against the current one they are the source,
+    the thumbnail's own file type, and `chr(109)` — the size letter `m`.
+    """
+    photo = "AgACAgIAAxkBAAIENGfeY4AfRquwTL2LpDrzqvFMVNt_AAIG9DEbXX3wSq3oI7t_PqQGAQADAgADbQADNgQ"
+
+    decoded = FileId.decode(photo)
+
+    assert decoded.minor == 54
+    assert decoded.thumbnail_source == ThumbnailSource.THUMBNAIL
+    assert decoded.thumbnail_file_type == FileType.PHOTO
+    assert decoded.thumbnail_size == "m"
+    assert decoded.volume_id is None
+    assert decoded.local_id is None
+
+    check(photo, FileType.PHOTO)
+
+
+NEW_LAYOUT_SOURCES = [
+    pytest.param(
+        ThumbnailSource.LEGACY,
+        struct.pack("<q", SECRET),
+        {"secret": SECRET},
+        id="legacy",
+    ),
+    pytest.param(
+        ThumbnailSource.THUMBNAIL,
+        struct.pack("<ii", FileType.PHOTO, ord("m")),
+        {"thumbnail_file_type": FileType.PHOTO, "thumbnail_size": "m"},
+        id="thumbnail",
+    ),
+    pytest.param(
+        ThumbnailSource.CHAT_PHOTO_SMALL,
+        struct.pack("<qq", CHAT_ID, CHAT_ACCESS_HASH),
+        {"chat_id": CHAT_ID, "chat_access_hash": CHAT_ACCESS_HASH},
+        id="chat_photo_small",
+    ),
+    pytest.param(
+        ThumbnailSource.CHAT_PHOTO_BIG,
+        struct.pack("<qq", CHAT_ID, CHAT_ACCESS_HASH),
+        {"chat_id": CHAT_ID, "chat_access_hash": CHAT_ACCESS_HASH},
+        id="chat_photo_big",
+    ),
+    pytest.param(
+        ThumbnailSource.STICKER_SET_THUMBNAIL,
+        struct.pack("<qq", STICKER_SET_ID, STICKER_SET_ACCESS_HASH),
+        {"sticker_set_id": STICKER_SET_ID, "sticker_set_access_hash": STICKER_SET_ACCESS_HASH},
+        id="sticker_set_thumbnail",
+    ),
+    pytest.param(
+        ThumbnailSource.FULL_LEGACY,
+        struct.pack("<qqi", VOLUME_ID, SECRET, LOCAL_ID),
+        {"volume_id": VOLUME_ID, "secret": SECRET, "local_id": LOCAL_ID},
+        id="full_legacy",
+    ),
+    pytest.param(
+        ThumbnailSource.CHAT_PHOTO_SMALL_LEGACY,
+        struct.pack("<qqqi", CHAT_ID, CHAT_ACCESS_HASH, VOLUME_ID, LOCAL_ID),
+        {
+            "chat_id": CHAT_ID,
+            "chat_access_hash": CHAT_ACCESS_HASH,
+            "volume_id": VOLUME_ID,
+            "local_id": LOCAL_ID,
+        },
+        id="chat_photo_small_legacy",
+    ),
+    pytest.param(
+        ThumbnailSource.CHAT_PHOTO_BIG_LEGACY,
+        struct.pack("<qqqi", CHAT_ID, CHAT_ACCESS_HASH, VOLUME_ID, LOCAL_ID),
+        {
+            "chat_id": CHAT_ID,
+            "chat_access_hash": CHAT_ACCESS_HASH,
+            "volume_id": VOLUME_ID,
+            "local_id": LOCAL_ID,
+        },
+        id="chat_photo_big_legacy",
+    ),
+    pytest.param(
+        ThumbnailSource.STICKER_SET_THUMBNAIL_LEGACY,
+        struct.pack("<qqqi", STICKER_SET_ID, STICKER_SET_ACCESS_HASH, VOLUME_ID, LOCAL_ID),
+        {
+            "sticker_set_id": STICKER_SET_ID,
+            "sticker_set_access_hash": STICKER_SET_ACCESS_HASH,
+            "volume_id": VOLUME_ID,
+            "local_id": LOCAL_ID,
+        },
+        id="sticker_set_thumbnail_legacy",
+    ),
+    pytest.param(
+        ThumbnailSource.STICKER_SET_THUMBNAIL_VERSION,
+        struct.pack("<qqi", STICKER_SET_ID, STICKER_SET_ACCESS_HASH, STICKER_SET_VERSION),
+        {
+            "sticker_set_id": STICKER_SET_ID,
+            "sticker_set_access_hash": STICKER_SET_ACCESS_HASH,
+            "sticker_set_version": STICKER_SET_VERSION,
+        },
+        id="sticker_set_thumbnail_version",
+    ),
+]
+
+
+@pytest.mark.parametrize("thumbnail_source, tail, expected", NEW_LAYOUT_SOURCES)
+def test_every_source_of_the_current_layout(thumbnail_source, tail, expected):
+    file_id = photo_file_id(minor=32, thumbnail_source=thumbnail_source, tail=tail)
+
+    decoded = FileId.decode(file_id)
+
+    assert decoded.thumbnail_source == thumbnail_source
+    assert decoded.media_id == MEDIA_ID
+    assert decoded.access_hash == ACCESS_HASH
+    assert decoded.file_reference == FILE_REFERENCE
+
+    assert {name: vars(decoded)[name] for name in expected} == expected
+    assert decoded.encode() == file_id
+
+
+def test_the_pre_32_layout_still_reads_as_before():
+    """Minor 31 keeps `volume_id` ahead of the source and `local_id` after every tail."""
+    payload = (
+        struct.pack("<ii", FileType.PHOTO | FILE_REFERENCE_FLAG, DC_ID)
+        + Bytes(FILE_REFERENCE)
+        + struct.pack("<qq", MEDIA_ID, ACCESS_HASH)
+        + struct.pack("<q", VOLUME_ID)
+        + struct.pack("<i", ThumbnailSource.CHAT_PHOTO_SMALL)
+        + struct.pack("<qq", CHAT_ID, CHAT_ACCESS_HASH)
+        + struct.pack("<i", LOCAL_ID)
+        + struct.pack("<bb", 31, 4)
+    )
+    file_id = b64_encode(rle_encode(payload))
+
+    decoded = FileId.decode(file_id)
+
+    assert decoded.volume_id == VOLUME_ID
+    assert decoded.local_id == LOCAL_ID
+    assert decoded.chat_id == CHAT_ID
+    assert decoded.chat_access_hash == CHAT_ACCESS_HASH
+    assert decoded.encode() == file_id
 
 
 def test_stringify_file_id():

--- a/tests/test_file_id.py
+++ b/tests/test_file_id.py
@@ -366,6 +366,159 @@ def test_the_pre_32_layout_still_reads_as_before():
     assert decoded.encode() == file_id
 
 
+def test_the_library_still_mints_the_layout_it_always_did():
+    """`FileId.MINOR` is untouched, so nothing this library hands out changes shape.
+
+    Every file id built by `types/` passes `volume_id=0, local_id=0` because the pre-32 layout has
+    nowhere to omit them. Should `MINOR` ever be raised past 32, those two arguments become dead and
+    this test is the one that says so.
+    """
+    minted = FileId(
+        file_type=FileType.PHOTO,
+        dc_id=DC_ID,
+        media_id=MEDIA_ID,
+        access_hash=ACCESS_HASH,
+        file_reference=FILE_REFERENCE,
+        thumbnail_source=ThumbnailSource.THUMBNAIL,
+        thumbnail_file_type=FileType.PHOTO,
+        thumbnail_size="m",
+        volume_id=0,
+        local_id=0,
+    ).encode()
+
+    decoded = FileId.decode(minted)
+
+    assert decoded.minor == 30
+    assert decoded.volume_id == 0
+    assert decoded.local_id == 0
+    assert decoded.encode() == minted
+
+
+def test_full_legacy_keeps_secret_between_volume_id_and_local_id():
+    """The field order here is TDLib's `FullLegacy::store`, not the schema's.
+
+    `inputPhotoLegacyFileLocation` lists the same three as `volume_id local_id secret`, so reading
+    the schema alone would swap the last two and silently produce a wrong `local_id`.
+    """
+    file_id = photo_file_id(
+        minor=32,
+        thumbnail_source=ThumbnailSource.FULL_LEGACY,
+        tail=struct.pack("<qqi", VOLUME_ID, SECRET, LOCAL_ID),
+    )
+
+    decoded = FileId.decode(file_id)
+
+    assert decoded.volume_id == VOLUME_ID
+    assert decoded.secret == SECRET
+    assert decoded.local_id == LOCAL_ID
+
+
+def test_a_source_past_the_known_ones_is_still_rejected():
+    """Nine is the last source TDLib defines; ten has to stay an error rather than a bad read."""
+    file_id = photo_file_id(minor=32, thumbnail_source=10, tail=struct.pack("<q", SECRET))
+
+    with pytest.raises(ValueError, match=r"Unknown thumbnail_source 10 of file_id \w+"):
+        FileId.decode(file_id)
+
+
+def test_documents_are_unaffected_by_the_photo_layout():
+    """Only `PHOTO_TYPES` carry a source, so a document must read the same at any minor."""
+    for minor in (30, 32, 54):
+        payload = (
+            struct.pack("<ii", FileType.DOCUMENT | FILE_REFERENCE_FLAG, DC_ID)
+            + Bytes(FILE_REFERENCE)
+            + struct.pack("<qq", MEDIA_ID, ACCESS_HASH)
+            + struct.pack("<bb", minor, 4)
+        )
+        file_id = b64_encode(rle_encode(payload))
+
+        decoded = FileId.decode(file_id)
+
+        assert decoded.file_type == FileType.DOCUMENT
+        assert decoded.media_id == MEDIA_ID
+        assert decoded.access_hash == ACCESS_HASH
+        assert decoded.volume_id is None
+        assert decoded.encode() == file_id
+
+
+EXTREMES = [0, 1, -1, 2 ** 62, -(2 ** 62), 2 ** 63 - 1, -(2 ** 63)]
+
+# `local_id` is an int32 and TDLib notes it can be negative in secret chat thumbnails.
+SMALL_EXTREMES = [0, 1, -1, 2 ** 31 - 1, -(2 ** 31)]
+
+
+def photo_fields(*, thumbnail_source: ThumbnailSource, big: int, small: int) -> dict:
+    """The fields a given source carries, filled with one value each."""
+    if thumbnail_source == ThumbnailSource.LEGACY:
+        return {"secret": big}
+
+    if thumbnail_source == ThumbnailSource.THUMBNAIL:
+        return {"thumbnail_file_type": FileType.PHOTO, "thumbnail_size": "y"}
+
+    if thumbnail_source in (ThumbnailSource.CHAT_PHOTO_SMALL, ThumbnailSource.CHAT_PHOTO_BIG):
+        return {"chat_id": big, "chat_access_hash": big}
+
+    if thumbnail_source == ThumbnailSource.STICKER_SET_THUMBNAIL:
+        return {"sticker_set_id": big, "sticker_set_access_hash": big}
+
+    if thumbnail_source == ThumbnailSource.FULL_LEGACY:
+        return {"volume_id": big, "secret": big, "local_id": small}
+
+    if thumbnail_source in (
+        ThumbnailSource.CHAT_PHOTO_SMALL_LEGACY,
+        ThumbnailSource.CHAT_PHOTO_BIG_LEGACY
+    ):
+        return {"chat_id": big, "chat_access_hash": big, "volume_id": big, "local_id": small}
+
+    if thumbnail_source == ThumbnailSource.STICKER_SET_THUMBNAIL_LEGACY:
+        return {
+            "sticker_set_id": big,
+            "sticker_set_access_hash": big,
+            "volume_id": big,
+            "local_id": small,
+        }
+
+    return {"sticker_set_id": big, "sticker_set_access_hash": big, "sticker_set_version": small}
+
+
+@pytest.mark.parametrize("thumbnail_source", list(ThumbnailSource))
+def test_every_source_survives_a_round_trip_at_its_extremes(thumbnail_source):
+    """Encode, decode, encode again for every source against the widest values each field holds.
+
+    The hand-built fixtures pin the layout; this pins the widths. A `<q` typed as `<i` somewhere
+    still round trips small numbers and only shows up at the ends of the range.
+    """
+    for big, small in zip(EXTREMES, SMALL_EXTREMES * 2):
+        # Before minor 32 every source shared one layout, and the ones added for it cannot occur.
+        minors = [32] if thumbnail_source >= ThumbnailSource.FULL_LEGACY else [30, 32]
+
+        for minor in minors:
+            fields = photo_fields(thumbnail_source=thumbnail_source, big=big, small=small)
+
+            if minor < 32:
+                fields.setdefault("volume_id", big)
+                fields.setdefault("local_id", small)
+
+            file_id = FileId(
+                minor=minor,
+                file_type=FileType.PHOTO,
+                dc_id=DC_ID,
+                media_id=MEDIA_ID,
+                access_hash=ACCESS_HASH,
+                file_reference=FILE_REFERENCE,
+                thumbnail_source=thumbnail_source,
+                **fields,
+            ).encode()
+
+            decoded = FileId.decode(file_id)
+
+            assert decoded.minor == minor
+            assert decoded.thumbnail_source == thumbnail_source
+
+            assert {name: vars(decoded)[name] for name in fields} == fields, thumbnail_source.name
+            assert decoded.encode() == file_id
+
+
 def test_stringify_file_id():
     file_id = "BQACAgIAAx0CAAGgr9AAAgmPX7b4UxbjNoFEO_L0I4s6wrXNJA8AAgQAA4GkuUm9FFvIaOhXWR4E"
     string = "{'major': 4, 'minor': 30, 'file_type': <FileType.DOCUMENT: 5>, 'dc_id': 2, " \


### PR DESCRIPTION
Closes #178.

## What

Photo file ids minted by current clients do not decode at all:

```python
FileId.decode(
    "AgACAgIAAxkBAAIENGfeY4AfRquwTL2LpDrzqvFMVNt_AAIG9DEbXX3wSq3oI7t_PqQGAQADAgADbQADNgQ"
)
# -> ValueError: Unknown thumbnail_source 109 of file_id AgACAgI...
```

`decode()` reads one photo layout unconditionally: eight bytes of `volume_id`, then the
source, then a per-source tail ending in `local_id`. TDLib dropped `volume_id` and
`local_id` from photo file ids at minor 32 — `Version::RemovePhotoVolumeAndLocalId` — and
gave the sources that still carry them values of their own, 5 to 9. Everything Telegram
hands out today is past that version, so the eight bytes we skip are not `volume_id` and
the four we read as the source are already part of the tail.

The id above is minor 54. The twelve bytes after `access_hash` are `01000000 02000000
6d000000`: source `THUMBNAIL`, the thumbnail's own file type `PHOTO`, and `chr(109)` — the
size letter `m`. Against the old layout the first eight become `volume_id` and `6d000000`
becomes the source, hence 109.

`ThumbnailSource` gains the five members it never had:

```python
FULL_LEGACY = 5
CHAT_PHOTO_SMALL_LEGACY = 6            # DialogPhotoSmallLegacy
CHAT_PHOTO_BIG_LEGACY = 7              # DialogPhotoBigLegacy
STICKER_SET_THUMBNAIL_LEGACY = 8
STICKER_SET_THUMBNAIL_VERSION = 9
```

and both `decode()` and `encode()` gate the two fields on the version, with each source
writing only its own tail in between:

```python
has_volume_and_local_id = minor < NO_VOLUME_AND_LOCAL_ID_MINOR
```

`STICKER_SET_THUMBNAIL_VERSION` carries a `thumb_version` where the older sticker sources
carry `volume_id` and `local_id`, so `FileId` grows a `sticker_set_version` to hold it.
`get_file()` treats `CHAT_PHOTO_BIG_LEGACY` as big, the same as `CHAT_PHOTO_BIG`.

One ordering worth flagging, since reading the schema alone gets it wrong.
`inputPhotoLegacyFileLocation` lists `volume_id local_id secret`, but the file id is
TDLib's own blob and follows `FullLegacy::store`, which writes `volume_id secret local_id`.
Taking the schema order swaps the last two and silently yields a wrong `local_id`.

## What does not change

`FileId.MINOR` stays at 30, so nothing this library hands out changes shape. `encode()`
defaults to the instance's own minor, so a decoded id round trips byte for byte at whatever
version it arrived with, and the ids built in `types/` keep passing `volume_id=0,
local_id=0` and keep coming out in the pre-32 layout. Raising `MINOR` past 32 would let
those two arguments go, but it changes bytes we hand to callers and belongs in its own
change, not in a decode fix. `test_the_library_still_mints_the_layout_it_always_did` pins
that.

Documents are untouched — only `PHOTO_TYPES` carry a source at all.

`get_file()` is the one place in the library that branches on the source rather than on the
file type, so the `big=` above is the whole of the consumer side; everything else in
`types/` only ever mints a source it already knows.

`FileUniqueId` is deliberately left alone. Its photo branch reads a fixed
`volume_id local_id`, and TDLib stopped writing that pair too — by
`PhotoRemoteFileLocation::AsKey::store` a `Thumbnail`, `DialogPhotoSmall` or
`DialogPhotoBig` unique id is now `id_` plus one byte of `PhotoSizeSource::get_unique()`,
and `StickerSetThumbnailVersion` is `"\x02"` plus `sticker_set_id` and `version`:

```python
FileUniqueId.decode(...)
# -> struct.error: unpack requires a buffer of 12 bytes
```

That is a different string, a different decoder and new public fields on `FileUniqueId`,
and it does not block #178. Happy to fold it in here if you would rather have both at once.

## How to test

```python
from pyrogram.file_id import FileId

# Any photo file id from a bot API response, or the one from #178:
FileId.decode(
    "AgACAgIAAxkBAAIENGfeY4AfRquwTL2LpDrzqvFMVNt_AAIG9DEbXX3wSq3oI7t_PqQGAQADAgADbQADNgQ"
)
```

`tests/test_file_id.py` goes from 22 to 74 tests, in three layers:

- Ten hand-built fixtures, one per source, assembled byte for byte the way
  `FullRemoteFileLocation::store` does rather than through `FileId.encode()` — so a case
  asserts the layout TDLib writes, not merely that our own two halves agree with each other.
- A round trip per source at the extremes of every field (`0`, `±1`, `±2**62`, `2**63 - 1`,
  `-2**63`, and the int32 ends for `local_id`), which is what catches a `<q` typed as `<i`.
- Regressions: the pre-32 layout still reads as before, documents read the same at minor 30,
  32 and 54, and source 10 is still rejected rather than read as something.

Both commits were run on their own, not only the branch tip: 60 and 74.
