### PR TITLE
fix(message): guard the optional `saved_peer_id` in a direct-messages chat

### DIFF
--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -1858,7 +1858,7 @@ class Message(Object, Update):
                 except (ChannelPrivate, ChannelForumMissing):
                     pass
 
-        if chat.type == enums.ChatType.DIRECT:
+        if chat.type == enums.ChatType.DIRECT and message.saved_peer_id:
             parsed_message.direct_messages_topic_id = message.saved_peer_id.user_id
 
             parsed_topic = client.topic_cache[(parsed_message.chat.id, parsed_message.direct_messages_topic_id)]

--- a/tests/types/__init__.py
+++ b/tests/types/__init__.py
@@ -1,0 +1,17 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/types/messages_and_media/__init__.py
+++ b/tests/types/messages_and_media/__init__.py
@@ -1,0 +1,17 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/types/messages_and_media/test_message.py
+++ b/tests/types/messages_and_media/test_message.py
@@ -1,0 +1,83 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+import pyrogram
+from pyrogram import enums, raw, types
+
+CHANNEL_ID = 1000000000
+USER_ID = 777000
+DATE = 1755100000
+
+
+def client():
+    return pyrogram.Client("test", api_id=1, api_hash="0" * 32, in_memory=True)
+
+
+def monoforum_chat():
+    return raw.types.Channel(
+        id=CHANNEL_ID,
+        title="Direct messages",
+        photo=raw.types.ChatPhotoEmpty(),
+        date=DATE,
+        broadcast=True,
+        monoforum=True,
+        access_hash=0,
+        usernames=[],
+        restriction_reason=[]
+    )
+
+
+def message(*, saved_peer_id=None):
+    return raw.types.Message(
+        id=1,
+        peer_id=raw.types.PeerChannel(channel_id=CHANNEL_ID),
+        from_id=raw.types.PeerUser(user_id=USER_ID),
+        saved_peer_id=saved_peer_id,
+        date=DATE,
+        message="hi",
+        entities=[],
+        restriction_reason=[]
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_direct_message_without_a_topic_parses():
+    parsed = await types.Message._parse(
+        client(),
+        message(),
+        users={},
+        chats={CHANNEL_ID: monoforum_chat()}
+    )
+
+    assert parsed.chat.type == enums.ChatType.DIRECT
+    assert parsed.direct_messages_topic_id is None
+    assert parsed.topic is None
+
+
+@pytest.mark.asyncio
+async def test_a_direct_message_with_a_topic_keeps_its_id():
+    parsed = await types.Message._parse(
+        client(),
+        message(saved_peer_id=raw.types.PeerUser(user_id=USER_ID)),
+        users={},
+        chats={CHANNEL_ID: monoforum_chat()}
+    )
+
+    assert parsed.direct_messages_topic_id == USER_ID


### PR DESCRIPTION
Closes #349.

## What

`Message._parse_message()` read `saved_peer_id` unguarded on the direct-messages branch:

```python
if chat.type == enums.ChatType.DIRECT:
    parsed_message.direct_messages_topic_id = message.saved_peer_id.user_id
```

The field is `flags.28?Peer` (`main_api.tl:133`), so a message that belongs to no topic arrives
without it and the read raises `AttributeError: 'NoneType' object has no attribute 'user_id'`.
Because `get_dialogs()` parses the last message of every dialog, one such message stops the whole
listing for the account, and no argument the caller passes avoids it.

The branch now asks for the field before using it:

```python
if chat.type == enums.ChatType.DIRECT and message.saved_peer_id:
```

`direct_messages_topic_id` stays `None`, as its annotation always allowed, and the topic lookup
below is skipped with it. That matters beyond the crash: the lookup is keyed on the value, so a
`None` could never hit `topic_cache`, and with `fetch_topics` on, every such message would have
gone to the network for a topic that does not exist.

## Tests

`tests/test_message.py`, two cases, both offline — they build the raw `Channel(monoforum=True)` and
`Message` by hand and call the parser directly, no account and no network:

- a direct message with no `saved_peer_id` parses, and comes back with
  `direct_messages_topic_id is None` and no topic;
- a direct message with one keeps the id it carries, so the guard did not cost the working path.

The first fails on `dev` with the `AttributeError` above and passes here. `pytest tests`: 48 → 50.

## What this does not change

`messageService#7a800e0a` declares `saved_peer_id:flags.28?Peer` as well, but service messages take
`_parse_service()`, which never reads it — so they cannot hit this crash, and they also never get a
`direct_messages_topic_id` at all. Giving them one is a behaviour change rather than a fix, so it
is left for the issue to settle. Happy to add it here if you want it in the same PR.
