### PR TITLE
fix(compiler): stop writing an empty `flags.N?Vector` the flags call absent

### DIFF
--- a/compiler/api/compiler.py
+++ b/compiler/api/compiler.py
@@ -531,7 +531,7 @@ def start(format: bool = False):
                     sub_type = arg_type.split("<")[1][:-1]
 
                     write_types += "\n        "
-                    write_types += f"if self.{arg_name} is not None:\n            "
+                    write_types += f"if self.{arg_name}:\n            "
                     write_types += "b.write(Vector(self.{}{}))\n        ".format(
                         arg_name, f", {sub_type.title()}" if sub_type in CORE_TYPES else ""
                     )

--- a/tests/raw/__init__.py
+++ b/tests/raw/__init__.py
@@ -1,0 +1,17 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/raw/test_optional_vector.py
+++ b/tests/raw/test_optional_vector.py
@@ -1,0 +1,150 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+
+from pyrogram import raw
+from pyrogram.raw.core import TLObject, Vector
+
+BLOCK = raw.types.PageBlockParagraph(text=raw.types.TextPlain(text="hi"))
+PHOTO = raw.types.InputPhoto(id=1, access_hash=2, file_reference=b"")
+# NOTE: `read()` gives a `flags.N?true` field `False`, never `None`, so the two `true` flags are
+#       spelled out here — otherwise the objects compare unequal for a reason this file is not about.
+USERNAME = raw.types.Username(username="name", editable=False, active=True)
+
+# One case per sub-type the generator branches on, plus a function and a class whose vector
+# lives in the second flags group. `build(None)` is the field never passed, `build([])` the
+# empty list, `build(items)` a real value.
+CASES = [
+    pytest.param(
+        lambda photos: raw.types.InputRichMessage(blocks=[BLOCK], photos=photos),
+        [PHOTO],
+        lambda message: message.photos,
+        id="Vector<InputPhoto>"
+    ),
+    pytest.param(
+        lambda usernames: raw.types.User(id=1, usernames=usernames),
+        [USERNAME],
+        lambda user: user.usernames,
+        id="Vector<Username>-in-flags2"
+    ),
+    pytest.param(
+        lambda slots: raw.functions.premium.ApplyBoost(peer=raw.types.InputPeerSelf(), slots=slots),
+        [1, 2],
+        lambda request: request.slots,
+        id="Vector<int>-in-a-function"
+    ),
+    pytest.param(
+        lambda users: raw.types.BusinessRecipients(users=users),
+        [10, 20],
+        lambda recipients: recipients.users,
+        id="Vector<long>"
+    ),
+    pytest.param(
+        lambda prefixes: raw.types.help.CountryCode(country_code="US", prefixes=prefixes),
+        ["7", "8"],
+        lambda country: country.prefixes,
+        id="Vector<string>"
+    ),
+    pytest.param(
+        lambda logout_tokens: raw.types.CodeSettings(logout_tokens=logout_tokens),
+        [b"\x01\x02"],
+        lambda settings: settings.logout_tokens,
+        id="Vector<bytes>"
+    )
+]
+
+
+@pytest.mark.parametrize(("build", "items", "read"), CASES)
+def test_an_empty_vector_is_written_as_absent(build, items, read):
+    assert build([]).write() == build(None).write()
+
+
+@pytest.mark.parametrize(("build", "items", "read"), CASES)
+def test_a_vector_with_items_is_still_written(build, items, read):
+    written = build(items).write()
+
+    assert written != build(None).write()
+    assert read(TLObject.read(BytesIO(written))) == items
+
+
+@pytest.mark.parametrize(
+    "value",
+    [lambda items: None, lambda items: [], lambda items: items],
+    ids=["never-passed", "empty", "filled"]
+)
+@pytest.mark.parametrize(("build", "items", "read"), CASES)
+def test_a_round_trip_is_byte_for_byte(build, items, read, value):
+    written = build(value(items)).write()
+    restored = TLObject.read(BytesIO(written))
+
+    assert restored.write() == written
+
+
+@pytest.mark.parametrize(("build", "items", "read"), CASES)
+def test_an_empty_vector_does_not_eat_the_object_after_it(build, items, read):
+    pair = Vector([build([]), build(items)])
+    first, second = TLObject.read(BytesIO(pair))
+
+    assert type(first) is type(second)
+    assert read(first) == []
+    assert read(second) == items
+
+
+def test_an_empty_vector_does_not_eat_the_field_after_it():
+    country = raw.types.help.CountryCode(country_code="US", prefixes=[], patterns=["+1 (###) ###"])
+    restored = TLObject.read(BytesIO(country.write()))
+
+    assert restored.prefixes == []
+    assert restored.patterns == ["+1 (###) ###"]
+
+
+def test_an_empty_vector_does_not_eat_a_field_from_the_next_flags_group():
+    user = raw.types.User(id=1, restriction_reason=[], usernames=[USERNAME], lang_code="en")
+    restored = TLObject.read(BytesIO(user.write()))
+
+    assert restored.restriction_reason == []
+    assert restored.lang_code == "en"
+    assert restored.usernames == [USERNAME]
+
+
+VECTOR_FIELD = re.compile(r"^        self\.(\w+) = \w+  # flags\d?\.\d+\?Vector<", re.MULTILINE)
+
+
+def test_no_generated_class_writes_an_optional_vector_it_did_not_announce():
+    checked = 0
+    written_by_identity = []
+
+    for path in sorted(Path(raw.__file__).parent.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+
+        for name in VECTOR_FIELD.findall(source):
+            checked += 1
+
+            if f"if self.{name} is not None:" in source:
+                written_by_identity.append(f"{path.name}: {name}")
+
+    assert written_by_identity == []
+
+    # The schema has 146 fields of this shape; a collector that stopped matching would otherwise
+    # pass with an empty list.
+    assert checked > 100


### PR DESCRIPTION
Closes #351.

## What

For a `flags.N?Vector<...>` field the generator set the flag bit by truthiness and wrote the
payload by identity, so an empty list put bytes on the wire that the flags said were not there.
One line in `compiler/api/compiler.py:534` — the payload now goes out on the same condition the
flag is already decided on:

```python
write_types += f"if self.{arg_name}:\n            "
```

`pyrogram/raw/` is generated at build time (`hatch_build.py:31-32`), so there is no regenerated
diff here. The scalar branches are untouched — they use `is not None` on both sides and were
already consistent.

## This is not only a round trip: the server rejects the request

`messages.search` is read-only and `saved_reaction` is `flags.3?Vector<Reaction>`, sitting before
`filter`, `min_date`, `max_date`, `offset_id`, `add_offset`, `limit`, `max_id`, `min_id` and
`hash`. Same request twice against a real account, once with the field left out and once with
`[]`:

```python
request = raw.functions.messages.Search(
    peer=peer, q="probe", saved_reaction=saved_reaction,
    filter=raw.types.InputMessagesFilterEmpty(),
    min_date=0, max_date=0, offset_id=0, add_offset=0, limit=1, max_id=0, min_id=0, hash=0
)
await client.invoke(request)
```

On `dev`:

```
saved_reaction=None: 80 bytes -> Messages, 0 messages
saved_reaction=[]:   88 bytes -> InputRequestTooLong: Telegram says: [400 INPUT_REQUEST_TOO_LONG]
                                - The request payload is too long. (caused by "messages.Search")
```

With this change, both are 80 bytes and both return `Messages`. So the eight bytes are not a
cosmetic asymmetry — the server parses the rest of the request from the wrong offset and refuses
it. `messages.search` happens to fail loudly; a layout where the stray bytes land on plain `int`
fields is parsed as a *different, valid* request instead, and nothing on either side reports it.

Where an empty list comes from in practice: the text paths inside the library are already careful
(`html.py:189`, `utils.py:678` and `parser.py:52` all end in `or None`), but 23 call sites pass a
caller-supplied list straight through — `send_poll(correct_option_ids=...)`,
`send_invoice(suggested_tip_amounts=...)`, `PhoneNumberAuthenticationSettings.authentication_tokens`
among them — and any raw object that was *read* before being written carries `[]` in every absent
vector by construction.

## Before and after

Generated code, `inputRichMessage` (146 fields in `main_api.tl` have this shape, 92 distinct
names, so this is every one of them):

```python
# before
flags |= (1 << 2) if self.photos else 0     # empty list -> bit stays 0
...
if self.photos is not None:                 # ... but the vector is written anyway
    b.write(Vector(self.photos))

# after
flags |= (1 << 2) if self.photos else 0
...
if self.photos:
    b.write(Vector(self.photos))
```

What that changes, observably:

| | before | after |
|---|---|---|
| `x.write()` with `field=[]` | flag unset, 8 unannounced bytes on the wire | flag unset, nothing written |
| `x.write()` with `field=None` | same 8 bytes (`read()` hands `[]` to absent vectors, and `[] is not None`) | nothing written |
| `x.write()` with `field=[item]` | flag set, vector written | unchanged |
| `TLObject.read(BytesIO(x.write())).write()` | different bytes than `x.write()` | byte for byte identical |
| two objects in a row, first with `field=[]` | second one comes back as a `List` | both come back as themselves |
| a field *after* the empty vector | read from the vector's bytes, silently wrong | read correctly |

Concretely, on `dev`:

```python
data = raw.types.InputRichMessage(blocks=[block]).write()
restored = TLObject.read(BytesIO(data))
len(data), len(restored.write())        # (28, 52)

pair = Vector([raw.types.InputRichMessage(blocks=[block], photos=[]),
               raw.types.InputRichMessage(blocks=[block])])
[type(item).__name__ for item in TLObject.read(BytesIO(pair))]
# ['InputRichMessage', 'List']
```

and with this change: `(28, 28)` and `['InputRichMessage', 'InputRichMessage']`.

Nothing a caller does changes. `[]` keeps meaning "absent", which is what `read()` already
produces for a flag that is not set, and a non-empty vector is written exactly as before.

## Tests

`tests/raw/test_optional_vector.py` — no account, no network. Six parametrized cases, one per
shape the generator branches on: `Vector<InputPhoto>` (objects), `Vector<Username>` in a second
flags group (`flags2`), `Vector<int>` inside a *function* rather than a type, `Vector<long>`,
`Vector<string>`, `Vector<bytes>`. Each case is built three ways — field never passed, `[]`,
a real value — and asserts:

- an empty vector produces the same bytes as one that was never passed;
- a vector with items still travels and reads back equal, so the fix does not silence real data;
- a round trip is byte for byte: `write()` → `read()` → `write()`, in all three states;
- an empty vector does not consume the object serialised after it.

Two more, for corruption inside a single object: a field after the empty vector
(`help.countryCode.patterns`), and one in the *next* flags group (`user.usernames` behind
`flags2`, after an empty `restriction_reason`).

And one sweep over the generated tree: all 146 optional-vector fields across 3218 modules must be
written on the flag condition, so a future generator change cannot bring this back for a subtype
nobody thought to add a case for.

With the generator line reverted and the API regenerated, 28 of the 39 new tests fail on `dev`.
`pytest tests`: 48 → 87.

## Note

Absent still has three spellings across the generated code — the constructor defaults to `None`,
`read()` produces `[]` — and #351 says more about that. This PR only removes the contradiction
inside `write()`.
