### PR TITLE
fix(errors): raise the verification errors instead of a bare `Forbidden`, and annotate `RPCError`

### DIFF
--- a/compiler/errors/source/403_FORBIDDEN.tsv
+++ b/compiler/errors/source/403_FORBIDDEN.tsv
@@ -2,6 +2,7 @@ id	message
 ACCESS_DENIED	You cannot perform this request.
 ALLOW_PAYMENT_REQUIRED_X	The user has enabled paid messages with {value} stars.
 ANONYMOUS_REACTIONS_DISABLED	Sorry, anonymous administrators cannot leave reactions or participate in polls.
+APNS_VERIFY_CHECK_X	The request can't be completed unless the APNs verification {value} is performed.
 BOT_ACCESS_FORBIDDEN	You can't access this bot.
 BOT_FORUM_CREATE_FORBIDDEN	This bot prevents users from creating or deleting topics.
 BOT_GUARD_NOT_SUPPORTED	This bot is not designated as a "join guard" bot. This method is only available to bots that mediate user joins to chats. .
@@ -35,6 +36,7 @@ GROUPCALL_ALREADY_STARTED	The groupcall has already started, you can join direct
 GROUPCALL_CHANGE_FORBIDDEN	You cannot change this group call setting.
 GROUPCALL_FORBIDDEN	The group call has already ended.
 INLINE_BOT_REQUIRED	The action must be performed through an inline bot callback.
+INTEGRITY_CHECK_CLASSIC_X	The request can't be completed unless the classic Play Integrity verification {value} is performed.
 LIVE_DISABLED	Story is disabled server-side.
 MESSAGE_AUTHOR_REQUIRED	You are not the author of this message.
 MESSAGE_DELETE_FORBIDDEN	You don't have rights to delete one of the messages you tried to delete, most likely because it is a service message or you are not the author of them.

--- a/pyrogram/errors/rpc_error.py
+++ b/pyrogram/errors/rpc_error.py
@@ -33,9 +33,9 @@ STRING_PARAMETER_PREFIXES: Final[Tuple[str, ...]] = (
 )
 PARAMETER: Final[Pattern[str]] = re.compile(r"_(\d+)")
 
-# NOTE: Canonical: `compiler/errors/compiler.py`, which writes one row per code keyed `"_"`,
-#       holding the name of the category class that code's errors subclass — `BadRequest` for 400,
-#       `Forbidden` for 403. It is what an error whose message is not in the table falls back to.
+# Canonical: `compiler/errors/compiler.py`, which writes one row per code keyed `"_"`, holding the
+# name of the category class that code's errors subclass — `BadRequest` for 400, `Forbidden` for
+# 403. It is what an error whose message is not in the table falls back to.
 CATEGORY: Final[str] = "_"
 
 
@@ -46,25 +46,25 @@ class _MessageParts:
 
 
 def _split_error_message(error_message: str) -> _MessageParts:
-    # NOTE: The three verification errors are the only ones whose parameters are a string rather
-    #       than a number, so `PARAMETER` rewrites part of the payload and yields an id that
-    #       matches no table row: the caller gets a bare `Forbidden` instead of the error itself,
-    #       and every occurrence appends a line to `unknown_errors.txt`.
+    # The three verification errors are the only ones whose parameters are a string rather than a
+    # number, so `PARAMETER` rewrites part of the payload and yields an id that matches no table
+    # row: the caller gets a bare `Forbidden` instead of the error itself, and every occurrence
+    # appends a line to `unknown_errors.txt`.
     #
-    #       Reproduce, without the loop below:
-    #           RPCError.raise_it(
-    #               raw.types.RpcError(
-    #                   error_code=403,
-    #                   error_message="RECAPTCHA_CHECK_signup__6LdcABcDEFghIJKlmnOP"
-    #               ),
-    #               raw.functions.auth.SendCode
-    #           )
+    # Reproduce, without the loop below:
+    #     RPCError.raise_it(
+    #         raw.types.RpcError(
+    #             error_code=403,
+    #             error_message="RECAPTCHA_CHECK_signup__6LdcABcDEFghIJKlmnOP"
+    #         ),
+    #         raw.functions.auth.SendCode
+    #     )
     #
-    #           pyrogram.errors.exceptions.forbidden_403.Forbidden: Telegram says: [403 Forbidden]
-    #           - [403 RECAPTCHA_CHECK_signup__6LdcABcDEFghIJKlmnOP] (caused by "auth.SendCode")
+    #     pyrogram.errors.exceptions.forbidden_403.Forbidden: Telegram says: [403 Forbidden]
+    #     - [403 RECAPTCHA_CHECK_signup__6LdcABcDEFghIJKlmnOP] (caused by "auth.SendCode")
     #
-    #       TDLib splits the same three prefixes off before anything else looks at the message:
-    #       https://github.com/tdlib/td/blob/022d60202e446ad1287b9fb68e687c8a0760788b/td/telegram/net/NetQueryDispatcher.cpp#L112-L146
+    # TDLib splits the same three prefixes off before anything else looks at the message:
+    # https://github.com/tdlib/td/blob/022d60202e446ad1287b9fb68e687c8a0760788b/td/telegram/net/NetQueryDispatcher.cpp#L112-L146
     for prefix in STRING_PARAMETER_PREFIXES:
         if error_message.startswith(prefix):
             return _MessageParts(

--- a/pyrogram/errors/rpc_error.py
+++ b/pyrogram/errors/rpc_error.py
@@ -27,10 +27,10 @@ from .exceptions.all import exceptions
 
 
 class RPCError(Exception):
-    ID = None
-    CODE = None
-    NAME = None
-    MESSAGE = "{value}"
+    ID: Optional[str] = None
+    CODE: Optional[int] = None
+    NAME: Optional[str] = None
+    MESSAGE: str = "{value}"
 
     def __init__(
         self,
@@ -47,10 +47,13 @@ class RPCError(Exception):
             f'(caused by "{rpc_name}")' if rpc_name else ""
         ))
 
-        try:
-            self.value = int(value)
-        except (ValueError, TypeError):
-            self.value = value
+        self.value: Optional[Union[int, str, raw.types.RpcError]]
+
+        # `isdecimal()`, not `isdigit()`: the latter is true for "²" too, and `int("²")` raises.
+        if isinstance(value, str) and value.isdecimal():
+            value = int(value)
+
+        self.value = value
 
         if is_unknown:
             with open("unknown_errors.txt", "a", encoding="utf-8") as f:
@@ -85,8 +88,8 @@ class RPCError(Exception):
               is_unknown=True,
               is_signed=is_signed)
 
-        value = re.search(r"_(\d+)", error_message)
-        value = value.group(1) if value is not None else value
+        match = re.search(r"_(\d+)", error_message)
+        value = match.group(1) if match is not None else None
 
         raise getattr(
             import_module("pyrogram.errors"),

--- a/pyrogram/errors/rpc_error.py
+++ b/pyrogram/errors/rpc_error.py
@@ -17,13 +17,73 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
+from dataclasses import dataclass
 from datetime import datetime
 from importlib import import_module
-from typing import Optional, Type, Union
+from typing import Final, Optional, Pattern, Tuple, Type, Union
 
 from pyrogram import raw
 from pyrogram.raw.core import TLObject
 from .exceptions.all import exceptions
+
+STRING_PARAMETER_PREFIXES: Final[Tuple[str, ...]] = (
+    "APNS_VERIFY_CHECK_",
+    "INTEGRITY_CHECK_CLASSIC_",
+    "RECAPTCHA_CHECK_"
+)
+PARAMETER: Final[Pattern[str]] = re.compile(r"_(\d+)")
+
+# NOTE: Canonical: `compiler/errors/compiler.py`, which writes one row per code keyed `"_"`,
+#       holding the name of the category class that code's errors subclass — `BadRequest` for 400,
+#       `Forbidden` for 403. It is what an error whose message is not in the table falls back to.
+CATEGORY: Final[str] = "_"
+
+
+@dataclass(frozen=True)
+class _MessageParts:
+    error_id: str
+    value: Optional[str]
+
+
+def _split_error_message(error_message: str) -> _MessageParts:
+    # NOTE: The three verification errors are the only ones whose parameters are a string rather
+    #       than a number, so `PARAMETER` rewrites part of the payload and yields an id that
+    #       matches no table row: the caller gets a bare `Forbidden` instead of the error itself,
+    #       and every occurrence appends a line to `unknown_errors.txt`.
+    #
+    #       Reproduce, without the loop below:
+    #           RPCError.raise_it(
+    #               raw.types.RpcError(
+    #                   error_code=403,
+    #                   error_message="RECAPTCHA_CHECK_signup__6LdcABcDEFghIJKlmnOP"
+    #               ),
+    #               raw.functions.auth.SendCode
+    #           )
+    #
+    #           pyrogram.errors.exceptions.forbidden_403.Forbidden: Telegram says: [403 Forbidden]
+    #           - [403 RECAPTCHA_CHECK_signup__6LdcABcDEFghIJKlmnOP] (caused by "auth.SendCode")
+    #
+    #       TDLib splits the same three prefixes off before anything else looks at the message:
+    #       https://github.com/tdlib/td/blob/022d60202e446ad1287b9fb68e687c8a0760788b/td/telegram/net/NetQueryDispatcher.cpp#L112-L146
+    for prefix in STRING_PARAMETER_PREFIXES:
+        if error_message.startswith(prefix):
+            return _MessageParts(
+                error_id=f"{prefix}X",
+                value=error_message[len(prefix):]
+            )
+
+    match = PARAMETER.search(error_message)
+    if match is None:
+        return _MessageParts(error_id=error_message, value=None)
+
+    # The tables spell a parameter as `_X`, so the id of a message is the message with its numbers
+    # blanked out: `FLOOD_WAIT_42` is listed as `FLOOD_WAIT_X`. `sub()` rather than the first match
+    # alone, because the id is the shape of the whole message; no table id carries more than one
+    # parameter, which is why the single `search()` above is enough to read the value back.
+    return _MessageParts(
+        error_id=PARAMETER.sub("_X", error_message),
+        value=match.group(1)
+    )
 
 
 class RPCError(Exception):
@@ -39,21 +99,21 @@ class RPCError(Exception):
         is_unknown: bool = False,
         is_signed: bool = False
     ):
-        super().__init__("Telegram says: [{}{} {}] - {} {}".format(
-            "-" if is_signed else "",
-            self.CODE,
-            self.ID or self.NAME,
-            self.MESSAGE.format(value=value),
-            f'(caused by "{rpc_name}")' if rpc_name else ""
-        ))
+        code = f"-{self.CODE}" if is_signed else self.CODE
+        name = self.ID or self.NAME
+        description = self.MESSAGE.format(value=value)
+        caused_by = f' (caused by "{rpc_name}")' if rpc_name else ""
+        message = f"Telegram says: [{code} {name}] - {description}{caused_by}"
+
+        super().__init__(message)
 
         self.value: Optional[Union[int, str, raw.types.RpcError]]
 
         # `isdecimal()`, not `isdigit()`: the latter is true for "²" too, and `int("²")` raises.
         if isinstance(value, str) and value.isdecimal():
-            value = int(value)
-
-        self.value = value
+            self.value = int(value)
+        else:
+            self.value = value
 
         if is_unknown:
             with open("unknown_errors.txt", "a", encoding="utf-8") as f:
@@ -77,27 +137,27 @@ class RPCError(Exception):
                 is_signed=is_signed
             )
 
-        error_id = re.sub(r"_\d+", "_X", error_message)
+        errors = import_module("pyrogram.errors")
 
-        if error_id not in exceptions[error_code]:
-            raise getattr(
-                import_module("pyrogram.errors"),
-                exceptions[error_code]["_"]
-            )(value=f"[{error_code} {error_message}]",
-              rpc_name=rpc_name,
-              is_unknown=True,
-              is_signed=is_signed)
+        parts = _split_error_message(error_message)
+        if parts.error_id not in exceptions[error_code]:
+            error_type = getattr(errors, exceptions[error_code][CATEGORY])
 
-        match = re.search(r"_(\d+)", error_message)
-        value = match.group(1) if match is not None else None
+            raise error_type(
+                value=f"[{error_code} {error_message}]",
+                rpc_name=rpc_name,
+                is_unknown=True,
+                is_signed=is_signed
+            )
 
-        raise getattr(
-            import_module("pyrogram.errors"),
-            exceptions[error_code][error_id]
-        )(value=value,
-          rpc_name=rpc_name,
-          is_unknown=False,
-          is_signed=is_signed)
+        error_type = getattr(errors, exceptions[error_code][parts.error_id])
+
+        raise error_type(
+            value=parts.value,
+            rpc_name=rpc_name,
+            is_unknown=False,
+            is_signed=is_signed
+        )
 
 
 class UnknownError(RPCError):

--- a/tests/errors/__init__.py
+++ b/tests/errors/__init__.py
@@ -1,0 +1,17 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/errors/test_rpc_error.py
+++ b/tests/errors/test_rpc_error.py
@@ -16,26 +16,37 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from pathlib import Path
+from typing import Dict, Final, Optional, Tuple, Type, Union
+
 import pytest
 
 from pyrogram import raw
 from pyrogram.errors import (
+    ApnsVerifyCheck,
     BadRequest,
     FloodWait,
+    IntegrityCheckClassic,
     PeerIdInvalid,
     PhoneMigrate,
+    RecaptchaCheck,
     RPCError,
     UnknownError
 )
 
-RPC_NAME = "messages.GetHistory"
+RPC_NAME: Final[str] = "messages.GetHistory"
+ATTRIBUTES: Final[Tuple[str, ...]] = ("ID", "CODE", "NAME", "MESSAGE")
 
 
-def raise_it(code, *, message):
+def raise_it(code: int, *, message: str) -> None:
     RPCError.raise_it(
         raw.types.RpcError(error_code=code, error_message=message),
         raw.functions.messages.GetHistory
     )
+
+
+def attributes_of(error_type: Type[RPCError]) -> Dict[str, Union[int, str, None]]:
+    return {name: getattr(error_type, name) for name in ATTRIBUTES}
 
 
 @pytest.mark.parametrize(
@@ -46,7 +57,12 @@ def raise_it(code, *, message):
         pytest.param(400, "PEER_ID_INVALID", PeerIdInvalid, None, id="no-number-at-all")
     ]
 )
-def test_a_known_error_takes_its_number_from_the_message(code, message, error_type, value):
+def test_a_known_error_takes_its_number_from_the_message(
+    code: int,
+    message: str,
+    error_type: Type[RPCError],
+    value: Optional[int]
+) -> None:
     with pytest.raises(error_type) as raised:
         raise_it(code, message=message)
 
@@ -56,30 +72,35 @@ def test_a_known_error_takes_its_number_from_the_message(code, message, error_ty
     assert type(error.value) is type(value)
 
 
-def test_a_negative_code_keeps_its_sign_in_the_text_only():
+def test_a_negative_code_keeps_its_sign_in_the_text_only() -> None:
     with pytest.raises(FloodWait) as raised:
         raise_it(-420, message="FLOOD_WAIT_42")
 
     error = raised.value
 
     assert error.CODE == 420
-    assert error.value == 42
-    assert str(error).startswith("Telegram says: [-420 FLOOD_WAIT_X]")
+    assert str(error) == (
+        "Telegram says: [-420 FLOOD_WAIT_X] - Please wait 42 seconds before repeating the action."
+        f' (caused by "{RPC_NAME}")'
+    )
 
 
-def test_the_message_template_is_filled_in_with_the_value():
+def test_the_message_template_is_filled_in_with_the_value() -> None:
     with pytest.raises(FloodWait) as raised:
         raise_it(420, message="FLOOD_WAIT_42")
 
-    text = str(raised.value)
+    assert str(raised.value) == (
+        "Telegram says: [420 FLOOD_WAIT_X] - Please wait 42 seconds before repeating the action."
+        f' (caused by "{RPC_NAME}")'
+    )
 
-    assert "Please wait 42 seconds before repeating the action." in text
-    assert f'(caused by "{RPC_NAME}")' in text
 
-
-def test_an_unknown_message_falls_back_to_the_class_of_its_code(tmp_path, monkeypatch):
+def test_an_unknown_message_falls_back_to_the_class_of_its_code(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch
+) -> None:
     # NOTE: An unknown error appends to `unknown_errors.txt` in the working directory
-    #       (`rpc_error.py:60-62`), which is why every unknown case runs somewhere disposable.
+    #       (`RPCError.__init__`), which is why every unknown case runs somewhere disposable.
     monkeypatch.chdir(tmp_path)
 
     with pytest.raises(BadRequest) as raised:
@@ -91,23 +112,27 @@ def test_an_unknown_message_falls_back_to_the_class_of_its_code(tmp_path, monkey
     assert type(error.value) is str
 
 
-def test_an_unknown_code_becomes_an_unknown_error(tmp_path, monkeypatch):
+def test_an_unknown_code_becomes_an_unknown_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.chdir(tmp_path)
 
     with pytest.raises(UnknownError) as raised:
         raise_it(999, message="A_CODE_THAT_IS_NOT_IN_THE_SCHEMA")
 
-    error = raised.value
-
-    assert error.CODE == 520
-    assert error.value == "[999 A_CODE_THAT_IS_NOT_IN_THE_SCHEMA]"
-
-    # `UnknownError` sets no `ID`, so the text has to fall back to `NAME`.
-    assert error.ID is None
-    assert str(error).startswith("Telegram says: [520 Unknown error]")
+    # `UnknownError` sets no `ID`, so the text falls back to `NAME`, and its `MESSAGE` is the
+    # inherited `"{value}"`, so the whole payload is what it renders.
+    assert str(raised.value) == (
+        "Telegram says: [520 Unknown error] - [999 A_CODE_THAT_IS_NOT_IN_THE_SCHEMA]"
+        f' (caused by "{RPC_NAME}")'
+    )
 
 
-def test_an_unknown_error_is_recorded_in_a_file(tmp_path, monkeypatch):
+def test_an_unknown_error_is_recorded_in_a_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.chdir(tmp_path)
 
     with pytest.raises(UnknownError):
@@ -119,7 +144,7 @@ def test_an_unknown_error_is_recorded_in_a_file(tmp_path, monkeypatch):
     assert RPC_NAME in written
 
 
-def test_a_known_error_records_nothing(tmp_path, monkeypatch):
+def test_a_known_error_records_nothing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
 
     with pytest.raises(FloodWait):
@@ -137,29 +162,119 @@ def test_a_known_error_records_nothing(tmp_path, monkeypatch):
         pytest.param(None, None, id="nothing-stays-nothing")
     ]
 )
-def test_value_keeps_whatever_is_not_a_number(value, expected):
+def test_value_keeps_whatever_is_not_a_number(
+    value: Union[int, str, None],
+    expected: Union[int, str, None]
+) -> None:
     error = FloodWait(value)
 
     assert error.value == expected
     assert type(error.value) is type(expected)
 
 
-def test_value_can_also_hold_the_raw_error_object():
+def test_value_can_also_hold_the_raw_error_object() -> None:
     rpc_error = raw.types.RpcError(error_code=400, error_message="PEER_ID_INVALID")
 
     assert RPCError(rpc_error).value is rpc_error
 
 
-def test_the_base_class_renders_without_any_of_its_attributes_set():
-    assert RPCError.ID is None
-    assert RPCError.CODE is None
-    assert RPCError.NAME is None
-    assert RPCError.MESSAGE == "{value}"
-    assert str(RPCError("something")).startswith("Telegram says: [None None] - something")
+@pytest.mark.parametrize(
+    ("error_type", "attributes"),
+    [
+        pytest.param(
+            RPCError,
+            {"ID": None, "CODE": None, "NAME": None, "MESSAGE": "{value}"},
+            id="the-base-class-sets-none-of-them"
+        ),
+        pytest.param(
+            FloodWait,
+            {
+                "ID": "FLOOD_WAIT_X",
+                "CODE": 420,
+                "NAME": "Flood",
+                "MESSAGE": "Please wait {value} seconds before repeating the action."
+            },
+            id="a-generated-subclass-sets-all-of-them"
+        )
+    ]
+)
+def test_an_error_class_declares_what_it_is(
+    error_type: Type[RPCError],
+    attributes: Dict[str, Union[int, str, None]]
+) -> None:
+    assert attributes_of(error_type) == attributes
 
 
-def test_a_generated_subclass_carries_all_four_attributes():
-    assert FloodWait.ID == "FLOOD_WAIT_X"
-    assert FloodWait.CODE == 420
-    assert FloodWait.NAME == "Flood"
-    assert FloodWait.MESSAGE == "Please wait {value} seconds before repeating the action."
+def test_the_base_class_renders_the_value_on_its_own() -> None:
+    assert str(RPCError("something")) == "Telegram says: [None None] - something"
+
+
+@pytest.mark.parametrize(
+    ("message", "error_type", "value"),
+    [
+        pytest.param(
+            "RECAPTCHA_CHECK_signup__6LdcABcDEFghIJKlmnOP",
+            RecaptchaCheck,
+            "signup__6LdcABcDEFghIJKlmnOP",
+            id="the-shape-telegram-sends"
+        ),
+        # The two strings TDLib feeds its own verification tests with:
+        # https://github.com/tdlib/td/blob/022d60202e446ad1287b9fb68e687c8a0760788b/td/telegram/net/NetQueryDispatcher.cpp#L73-L82
+        #
+        # The reCAPTCHA one carries an action with an underscore of its own, and TDLib splits it
+        # off at the *last* `__` — its loop keeps overwriting rather than breaking, so `AB_CD` is
+        # the action and `KEY` the site key id:
+        # https://github.com/tdlib/td/blob/022d60202e446ad1287b9fb68e687c8a0760788b/td/telegram/net/NetQueryDispatcher.cpp#L124-L130
+        #
+        # Nothing here splits them apart; `value` keeps the payload whole.
+        pytest.param(
+            "RECAPTCHA_CHECK_AB_CD__KEY",
+            RecaptchaCheck,
+            "AB_CD__KEY",
+            id="an-action-with-an-underscore"
+        ),
+        pytest.param("RECAPTCHA_CHECK_signup", RecaptchaCheck, "signup", id="no-key-at-all"),
+        pytest.param("RECAPTCHA_CHECK_", RecaptchaCheck, "", id="no-parameters-at-all"),
+        pytest.param("APNS_VERIFY_CHECK_ABCD", ApnsVerifyCheck, "ABCD", id="an-apns-nonce"),
+        pytest.param(
+            "INTEGRITY_CHECK_CLASSIC_ABCD",
+            IntegrityCheckClassic,
+            "ABCD",
+            id="a-play-integrity-nonce"
+        )
+    ]
+)
+def test_a_verification_error_keeps_its_parameters_whole(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    message: str,
+    error_type: Type[RPCError],
+    value: str
+) -> None:
+    # NOTE: Run somewhere disposable: before the prefixes were split off these raised a bare
+    #       `Forbidden` and appended to `unknown_errors.txt`, which is what the next test asserts
+    #       no longer happens.
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(error_type) as raised:
+        raise_it(403, message=message)
+
+    # Landing on `error_type` is what says the id was looked up whole; rendering the same text as
+    # the error built straight from the payload is what says the payload came through with it.
+    assert str(raised.value) == str(error_type(value, rpc_name=RPC_NAME))
+
+
+def test_a_verification_error_is_not_an_unknown_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(RecaptchaCheck) as raised:
+        raise_it(403, message="RECAPTCHA_CHECK_signup__6LdcABcDEFghIJKlmnOP")
+
+    assert not (tmp_path / "unknown_errors.txt").exists()
+    assert str(raised.value) == (
+        "Telegram says: [403 RECAPTCHA_CHECK_X] - The request can't be completed unless reCAPTCHA "
+        f'verification signup__6LdcABcDEFghIJKlmnOP is performed. (caused by "{RPC_NAME}")'
+    )

--- a/tests/errors/test_rpc_error.py
+++ b/tests/errors/test_rpc_error.py
@@ -99,8 +99,8 @@ def test_an_unknown_message_falls_back_to_the_class_of_its_code(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # NOTE: An unknown error appends to `unknown_errors.txt` in the working directory
-    #       (`RPCError.__init__`), which is why every unknown case runs somewhere disposable.
+    # An unknown error appends to `unknown_errors.txt` in the working directory
+    # (`RPCError.__init__`), which is why every unknown case runs somewhere disposable.
     monkeypatch.chdir(tmp_path)
 
     with pytest.raises(BadRequest) as raised:
@@ -280,9 +280,8 @@ def test_a_verification_error_keeps_its_parameters_whole(
     value: str,
     text: str
 ) -> None:
-    # NOTE: Run somewhere disposable: before the prefixes were split off these raised a bare
-    #       `Forbidden` and appended to `unknown_errors.txt`, which is what the next test asserts
-    #       no longer happens.
+    # Run somewhere disposable: before the prefixes were split off these raised a bare `Forbidden`
+    # and appended to `unknown_errors.txt`, which is what the next test asserts no longer happens.
     monkeypatch.chdir(tmp_path)
 
     with pytest.raises(error_type) as raised:

--- a/tests/errors/test_rpc_error.py
+++ b/tests/errors/test_rpc_error.py
@@ -1,0 +1,165 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from pyrogram import raw
+from pyrogram.errors import (
+    BadRequest,
+    FloodWait,
+    PeerIdInvalid,
+    PhoneMigrate,
+    RPCError,
+    UnknownError
+)
+
+RPC_NAME = "messages.GetHistory"
+
+
+def raise_it(code, *, message):
+    RPCError.raise_it(
+        raw.types.RpcError(error_code=code, error_message=message),
+        raw.functions.messages.GetHistory
+    )
+
+
+@pytest.mark.parametrize(
+    ("code", "message", "error_type", "value"),
+    [
+        pytest.param(420, "FLOOD_WAIT_42", FloodWait, 42, id="a-number-in-the-message"),
+        pytest.param(303, "PHONE_MIGRATE_2", PhoneMigrate, 2, id="another-number"),
+        pytest.param(400, "PEER_ID_INVALID", PeerIdInvalid, None, id="no-number-at-all")
+    ]
+)
+def test_a_known_error_takes_its_number_from_the_message(code, message, error_type, value):
+    with pytest.raises(error_type) as raised:
+        raise_it(code, message=message)
+
+    error = raised.value
+
+    assert error.value == value
+    assert type(error.value) is type(value)
+
+
+def test_a_negative_code_keeps_its_sign_in_the_text_only():
+    with pytest.raises(FloodWait) as raised:
+        raise_it(-420, message="FLOOD_WAIT_42")
+
+    error = raised.value
+
+    assert error.CODE == 420
+    assert error.value == 42
+    assert str(error).startswith("Telegram says: [-420 FLOOD_WAIT_X]")
+
+
+def test_the_message_template_is_filled_in_with_the_value():
+    with pytest.raises(FloodWait) as raised:
+        raise_it(420, message="FLOOD_WAIT_42")
+
+    text = str(raised.value)
+
+    assert "Please wait 42 seconds before repeating the action." in text
+    assert f'(caused by "{RPC_NAME}")' in text
+
+
+def test_an_unknown_message_falls_back_to_the_class_of_its_code(tmp_path, monkeypatch):
+    # NOTE: An unknown error appends to `unknown_errors.txt` in the working directory
+    #       (`rpc_error.py:60-62`), which is why every unknown case runs somewhere disposable.
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(BadRequest) as raised:
+        raise_it(400, message="SOMETHING_THE_SCHEMA_DOES_NOT_KNOW")
+
+    error = raised.value
+
+    assert error.value == "[400 SOMETHING_THE_SCHEMA_DOES_NOT_KNOW]"
+    assert type(error.value) is str
+
+
+def test_an_unknown_code_becomes_an_unknown_error(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(UnknownError) as raised:
+        raise_it(999, message="A_CODE_THAT_IS_NOT_IN_THE_SCHEMA")
+
+    error = raised.value
+
+    assert error.CODE == 520
+    assert error.value == "[999 A_CODE_THAT_IS_NOT_IN_THE_SCHEMA]"
+
+    # `UnknownError` sets no `ID`, so the text has to fall back to `NAME`.
+    assert error.ID is None
+    assert str(error).startswith("Telegram says: [520 Unknown error]")
+
+
+def test_an_unknown_error_is_recorded_in_a_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(UnknownError):
+        raise_it(999, message="A_CODE_THAT_IS_NOT_IN_THE_SCHEMA")
+
+    written = (tmp_path / "unknown_errors.txt").read_text(encoding="utf-8")
+
+    assert "[999 A_CODE_THAT_IS_NOT_IN_THE_SCHEMA]" in written
+    assert RPC_NAME in written
+
+
+def test_a_known_error_records_nothing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(FloodWait):
+        raise_it(420, message="FLOOD_WAIT_42")
+
+    assert not (tmp_path / "unknown_errors.txt").exists()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("42", 42, id="digits-become-a-number"),
+        pytest.param(42, 42, id="a-number-stays-one"),
+        pytest.param("FLOOD_WAIT_X", "FLOOD_WAIT_X", id="text-is-kept"),
+        pytest.param(None, None, id="nothing-stays-nothing")
+    ]
+)
+def test_value_keeps_whatever_is_not_a_number(value, expected):
+    error = FloodWait(value)
+
+    assert error.value == expected
+    assert type(error.value) is type(expected)
+
+
+def test_value_can_also_hold_the_raw_error_object():
+    rpc_error = raw.types.RpcError(error_code=400, error_message="PEER_ID_INVALID")
+
+    assert RPCError(rpc_error).value is rpc_error
+
+
+def test_the_base_class_renders_without_any_of_its_attributes_set():
+    assert RPCError.ID is None
+    assert RPCError.CODE is None
+    assert RPCError.NAME is None
+    assert RPCError.MESSAGE == "{value}"
+    assert str(RPCError("something")).startswith("Telegram says: [None None] - something")
+
+
+def test_a_generated_subclass_carries_all_four_attributes():
+    assert FloodWait.ID == "FLOOD_WAIT_X"
+    assert FloodWait.CODE == 420
+    assert FloodWait.NAME == "Flood"
+    assert FloodWait.MESSAGE == "Please wait {value} seconds before repeating the action."

--- a/tests/errors/test_rpc_error.py
+++ b/tests/errors/test_rpc_error.py
@@ -210,12 +210,14 @@ def test_the_base_class_renders_the_value_on_its_own() -> None:
 
 
 @pytest.mark.parametrize(
-    ("message", "error_type", "value"),
+    ("message", "error_type", "value", "text"),
     [
         pytest.param(
             "RECAPTCHA_CHECK_signup__6LdcABcDEFghIJKlmnOP",
             RecaptchaCheck,
             "signup__6LdcABcDEFghIJKlmnOP",
+            "Telegram says: [403 RECAPTCHA_CHECK_X] - The request can't be completed unless "
+            "reCAPTCHA verification signup__6LdcABcDEFghIJKlmnOP is performed.",
             id="the-shape-telegram-sends"
         ),
         # The two strings TDLib feeds its own verification tests with:
@@ -231,15 +233,41 @@ def test_the_base_class_renders_the_value_on_its_own() -> None:
             "RECAPTCHA_CHECK_AB_CD__KEY",
             RecaptchaCheck,
             "AB_CD__KEY",
+            "Telegram says: [403 RECAPTCHA_CHECK_X] - The request can't be completed unless "
+            "reCAPTCHA verification AB_CD__KEY is performed.",
             id="an-action-with-an-underscore"
         ),
-        pytest.param("RECAPTCHA_CHECK_signup", RecaptchaCheck, "signup", id="no-key-at-all"),
-        pytest.param("RECAPTCHA_CHECK_", RecaptchaCheck, "", id="no-parameters-at-all"),
-        pytest.param("APNS_VERIFY_CHECK_ABCD", ApnsVerifyCheck, "ABCD", id="an-apns-nonce"),
+        pytest.param(
+            "RECAPTCHA_CHECK_signup",
+            RecaptchaCheck,
+            "signup",
+            "Telegram says: [403 RECAPTCHA_CHECK_X] - The request can't be completed unless "
+            "reCAPTCHA verification signup is performed.",
+            id="no-key-at-all"
+        ),
+        # The template has nothing to put in its hole, hence the two spaces.
+        pytest.param(
+            "RECAPTCHA_CHECK_",
+            RecaptchaCheck,
+            "",
+            "Telegram says: [403 RECAPTCHA_CHECK_X] - The request can't be completed unless "
+            "reCAPTCHA verification  is performed.",
+            id="no-parameters-at-all"
+        ),
+        pytest.param(
+            "APNS_VERIFY_CHECK_ABCD",
+            ApnsVerifyCheck,
+            "ABCD",
+            "Telegram says: [403 APNS_VERIFY_CHECK_X] - The request can't be completed unless "
+            "the APNs verification ABCD is performed.",
+            id="an-apns-nonce"
+        ),
         pytest.param(
             "INTEGRITY_CHECK_CLASSIC_ABCD",
             IntegrityCheckClassic,
             "ABCD",
+            "Telegram says: [403 INTEGRITY_CHECK_CLASSIC_X] - The request can't be completed "
+            "unless the classic Play Integrity verification ABCD is performed.",
             id="a-play-integrity-nonce"
         )
     ]
@@ -249,7 +277,8 @@ def test_a_verification_error_keeps_its_parameters_whole(
     monkeypatch: pytest.MonkeyPatch,
     message: str,
     error_type: Type[RPCError],
-    value: str
+    value: str,
+    text: str
 ) -> None:
     # NOTE: Run somewhere disposable: before the prefixes were split off these raised a bare
     #       `Forbidden` and appended to `unknown_errors.txt`, which is what the next test asserts
@@ -259,9 +288,13 @@ def test_a_verification_error_keeps_its_parameters_whole(
     with pytest.raises(error_type) as raised:
         raise_it(403, message=message)
 
-    # Landing on `error_type` is what says the id was looked up whole; rendering the same text as
-    # the error built straight from the payload is what says the payload came through with it.
-    assert str(raised.value) == str(error_type(value, rpc_name=RPC_NAME))
+    error = raised.value
+
+    # The payload is what a caller acts on, the text is what a human reads. The text is spelled out
+    # rather than rendered from `value` a second time, because both sides of such a comparison would
+    # go through the same `MESSAGE` and neither would say anything about it.
+    assert error.value == value
+    assert str(error) == f'{text} (caused by "{RPC_NAME}")'
 
 
 def test_a_verification_error_is_not_an_unknown_error(
@@ -270,11 +303,7 @@ def test_a_verification_error_is_not_an_unknown_error(
 ) -> None:
     monkeypatch.chdir(tmp_path)
 
-    with pytest.raises(RecaptchaCheck) as raised:
+    with pytest.raises(RecaptchaCheck):
         raise_it(403, message="RECAPTCHA_CHECK_signup__6LdcABcDEFghIJKlmnOP")
 
     assert not (tmp_path / "unknown_errors.txt").exists()
-    assert str(raised.value) == (
-        "Telegram says: [403 RECAPTCHA_CHECK_X] - The request can't be completed unless reCAPTCHA "
-        f'verification signup__6LdcABcDEFghIJKlmnOP is performed. (caused by "{RPC_NAME}")'
-    )


### PR DESCRIPTION
## What

Two things about `pyrogram/errors/rpc_error.py`, in two commits.

### 1. The verification errors never reach their own classes

`raise_it()` builds the lookup id by rewriting every `_<digits>` run into `_X`, because that is how
the tables spell a parameter: `FLOOD_WAIT_42` -> `FLOOD_WAIT_X`. Telegram's verification errors
carry a string instead, and the rewrite corrupts it:

```python
RPCError.raise_it(
    raw.types.RpcError(error_code=403, error_message="RECAPTCHA_CHECK_signup__6LdcABcDEFghIJKlmnOP"),
    raw.functions.auth.SendCode
)
```
```
pyrogram.errors.exceptions.forbidden_403.Forbidden: Telegram says: [403 Forbidden] -
[403 RECAPTCHA_CHECK_signup__6LdcABcDEFghIJKlmnOP] (caused by "auth.SendCode")
```

`_6` in the middle of the site key becomes `_X`, the id ends up as
`RECAPTCHA_CHECK_signup__XLdcABcDEFghIJKlmnOP`, no table row matches, and the caller gets the bare
category class. `except RecaptchaCheck` never fires, and because the error is reported as unknown,
every occurrence also appends a line to `unknown_errors.txt` in the working directory.

There are three such errors, and TDLib splits all three off before anything else looks at the
message, in
[`NetQueryDispatcher.cpp#L112-L146`](https://github.com/tdlib/td/blob/022d60202e446ad1287b9fb68e687c8a0760788b/td/telegram/net/NetQueryDispatcher.cpp#L112-L146):
`RECAPTCHA_CHECK_` (action and reCAPTCHA site key), `APNS_VERIFY_CHECK_` and
`INTEGRITY_CHECK_CLASSIC_` (a nonce to verify with APNs and with Play Integrity respectively). The
last two are missing from the tables here, so they arrive as a bare `Forbidden` for a second
reason; this adds them, with the ids TDLib matches on:

```
APNS_VERIFY_CHECK_X          The request can't be completed unless the APNs verification {value} is performed.
INTEGRITY_CHECK_CLASSIC_X    The request can't be completed unless the classic Play Integrity verification {value} is performed.
```

Working out what to look up is now one function, and both of its paths produce the id and the
value together — before, the id came from one expression and the value from another, further down,
which is how the two could disagree in the first place:

```python
def _split_error_message(error_message: str) -> _MessageParts:
    for prefix in STRING_PARAMETER_PREFIXES:
        if error_message.startswith(prefix):
            return _MessageParts(
                error_id=f"{prefix}X",
                value=error_message[len(prefix):]
            )

    match = PARAMETER.search(error_message)
    if match is None:
        return _MessageParts(error_id=error_message, value=None)

    return _MessageParts(
        error_id=PARAMETER.sub("_X", error_message),
        value=match.group(1)
    )
```

`value` now holds the whole payload — `signup__6LdcABcDEFghIJKlmnOP` for the reCAPTCHA one, the
nonce for the other two — which is what the caller needs to act on the error.

### 2. `value`, `ID`, `CODE` and `NAME` say nothing about what they hold

`RPCError.value` carries no annotation, and its first assignment is `int(value)`, so mypy and every
IDE infer `int`. It holds three different things:

| error | `.value` |
| --- | --- |
| `FLOOD_WAIT_42`, `PHONE_MIGRATE_2` | `42`, `2` — `int` |
| `PEER_ID_INVALID` and every other message without `_<digits>` | `None` |
| an error the schema does not know | `'[400 SOMETHING_NEW]'` — `str` |

The library reads it as a number in three places — `session.py` (`amount = e.value`, then
`amount > sleep_threshold` and `asyncio.sleep(amount)`), `file_part=e.value` in the uploaders that
retry on `FilePartMissing`, and `storage.dc_id(e.value)` in the auth flow. Those are safe today
because the errors they catch always carry a number, but nothing says so: a caller who writes the
same thing for another error gets `TypeError: '>' not supported between instances of 'NoneType'
and 'int'` at runtime and no warning at all before that.

Same file, same nature: `ID`, `CODE` and `NAME` are declared as bare `None` on the base class, so
every subclass that sets them — all of `errors/exceptions/`, plus `UnknownError` right below —
contradicts the base.

Annotations only. `mypy pyrogram/errors/rpc_error.py` goes from 5 errors to none:

```python
ID: Optional[str] = None
CODE: Optional[int] = None
NAME: Optional[str] = None
MESSAGE: str = "{value}"
...
self.value: Optional[Union[int, str, raw.types.RpcError]]
```

The `try`/`except` around `int(value)` goes with them. It was there to catch `int(None)`, which is
the ordinary case — most messages carry no number — and the conversion is what made `value` look
like an `int` in the first place. Asking the string whether it is a number says the same thing
without the exception, and without reassigning the argument on the way:

```python
self.value: Optional[Union[int, str, raw.types.RpcError]]

if isinstance(value, str) and value.isdecimal():
    self.value = int(value)
else:
    self.value = value
```

`isdecimal()` rather than `isdigit()`, because `"²".isdigit()` is true and `int("²")` raises.

I did not change what `value` holds otherwise. Making it always `int`, or splitting the raw payload
into a second attribute, would break every caller that reads it today.

The text was assembled by `"Telegram says: [{}{} {}] - {} {}".format(...)` over five positional
holes, two of which were conditionals. Each piece is now named:

```python
code = f"-{self.CODE}" if is_signed else self.CODE
name = self.ID or self.NAME
description = self.MESSAGE.format(value=value)
caused_by = f' (caused by "{rpc_name}")' if rpc_name else ""
message = f"Telegram says: [{code} {name}] - {description}{caused_by}"

super().__init__(message)
```

That also drops a trailing space the old form always left behind when there was no `rpc_name` to
name — `str(RPCError("something"))` was `"Telegram says: [None None] - something "`. It is the only
change to the rendered text, and nothing in the library reads it back.

## Tests

`tests/errors/test_rpc_error.py`, no account and no network: everything goes through
`RPCError.raise_it()` with a real `raw.types.RpcError`. The shapes a message can take — a number in
it and no number at all, a signed code, the `MESSAGE` template and the `(caused by ...)` suffix, an
unknown message falling back to the class of its code, an unknown code becoming `UnknownError`,
`unknown_errors.txt` written for an unknown error and not written for a known one, direct
construction for each value `int()` cannot take, and the class attributes of the base and of a
generated subclass. Plus the verification errors, one case per shape: the reCAPTCHA payload Telegram
sends, a reCAPTCHA action that carries an underscore of its own, no site key at all, no parameters
at all, an APNs nonce and a Play Integrity nonce — the underscore case and the APNs nonce are the
strings TDLib feeds its own verification tests with, and the Play Integrity one mirrors them
([`#L73-L82`](https://github.com/tdlib/td/blob/022d60202e446ad1287b9fb68e687c8a0760788b/td/telegram/net/NetQueryDispatcher.cpp#L73-L82)) —
and one asserting the reCAPTCHA error is no longer reported as unknown. Each verification case
spells out both what the caller gets — the payload, whole — and the whole text the error renders,
which is also what pins the two message rows this adds: rendering a second error from the same
payload and comparing the two would have gone through the same `MESSAGE` template and said nothing
about it.

The unknown-error cases run in `tmp_path`, because `RPCError.__init__` appends to
`unknown_errors.txt` in the working directory.

That is 100% of `rpc_error.py`, branches included:

```
pytest tests/errors --cov=pyrogram.errors.rpc_error --cov-branch

Name                           Stmts   Miss Branch BrPart  Cover
pyrogram/errors/rpc_error.py      61      0     16      0   100%
```

`pytest tests`: 48 -> 72.

## Note

The two new table rows move the error count, which #357 asserts on. Whichever lands first, I will
rebase the other.

