### PR TITLE
fix(filters): let `business`, `linked_channel` and `topic` read the message an update is about

### DIFF
--- a/pyrogram/filters.py
+++ b/pyrogram/filters.py
@@ -193,6 +193,20 @@ def _is_outgoing(update: Update) -> bool:
     return bool(update.outgoing) if isinstance(update, _CAN_BE_OUTGOING) else False
 
 
+# NOTE: `business_connection_id`, `forward_origin` and `topic` live on `Message` alone, so the
+#       filters that read them cannot take the field off the update the way the ones above do.
+#       They go through the message the update is about instead, which is the same message the
+#       user is looking at when a button under it is pressed.
+_WITH_A_MESSAGE = (CallbackQuery,)
+
+
+def _message_of(update: Update) -> Optional[Message]:
+    if isinstance(update, Message):
+        return update
+
+    return update.message if isinstance(update, _WITH_A_MESSAGE) else None
+
+
 def create(func: Callable, name: Optional[str] = None, **kwargs) -> Filter:
     """Easily create a custom filter.
 
@@ -907,12 +921,13 @@ video_chat_ended = create(video_chat_ended_filter)
 # endregion
 
 # region business
-async def business_filter(_, __, message: Message):
-    return bool(message.business_connection_id)
+async def business_filter(_, __, update: Update):
+    message = _message_of(update)
+    return bool(message and message.business_connection_id)
 
 
 business = create(business_filter)
-"""Filter messages sent via business bot"""
+"""Filter updates sent via business bot"""
 
 
 # endregion
@@ -1005,8 +1020,10 @@ paid_message = create(paid_message_filter)
 # endregion
 
 # region linked_channel_filter
-async def linked_channel_filter(_, __, message: Message):
+async def linked_channel_filter(_, __, update: Update):
+    message = _message_of(update)
     return bool(
+        message and
         message.forward_origin and
         message.forward_origin.type == enums.MessageOriginType.CHANNEL and
         message.forward_origin.chat == message.sender_chat
@@ -1014,7 +1031,7 @@ async def linked_channel_filter(_, __, message: Message):
 
 
 linked_channel = create(linked_channel_filter)
-"""Filter messages that are automatically forwarded from the linked channel to the group chat."""
+"""Filter updates about a message that was automatically forwarded from the linked channel to the group chat."""
 
 
 # endregion
@@ -1262,14 +1279,14 @@ class chat(Filter, set):
 
 # noinspection PyPep8Naming
 class topic(Filter, set):
-    """Filter messages coming from one or more topics.
+    """Filter updates coming from one or more topics.
 
     You can use `set bound methods <https://docs.python.org/3/library/stdtypes.html#set>`_ to manipulate the
     topics container.
 
     Parameters:
         topics (``int`` | ``list``):
-            Pass one or more topic ids to filter messages in specific topics.
+            Pass one or more topic ids to filter updates in specific topics.
             Defaults to None (no topics).
     """
 
@@ -1280,5 +1297,7 @@ class topic(Filter, set):
             t for t in topics
         )
 
-    async def __call__(self, _, message: Message):
-        return message.topic and message.topic.id in self
+    async def __call__(self, _, update: Update):
+        message = _message_of(update)
+
+        return bool(message and message.topic and message.topic.id in self)

--- a/tests/filters/test_update_attributes.py
+++ b/tests/filters/test_update_attributes.py
@@ -216,6 +216,7 @@ def carries(update_type, field: str) -> bool:
         ("chat", filters._WITH_A_CHAT),
         ("sender_chat", filters._WITH_A_SENDER_CHAT),
         ("outgoing", filters._CAN_BE_OUTGOING),
+        ("message", filters._WITH_A_MESSAGE),
     ],
 )
 def test_the_filters_name_every_update_type_that_carries_the_field(field, declared):
@@ -238,6 +239,58 @@ def test_the_update_base_class_declares_no_fields():
     """
     for name in ("from_user", "chat", "sender_chat", "outgoing"):
         assert not hasattr(Update, name)
+
+
+A_TOPIC = types.ForumTopic(id=13)
+
+FROM_THE_LINKED_CHANNEL = {
+    "sender_chat": CHANNEL,
+    "forward_origin": types.MessageOriginChannel(chat=CHANNEL, message_id=1),
+}
+
+
+def business_message() -> Message:
+    return Message(id=1, chat=PRIVATE, business_connection_id="a_connection")
+
+
+@pytest.mark.asyncio
+async def test_business_reads_the_message_the_update_is_about():
+    assert await filters.business(CLIENT, business_message())
+    assert await filters.business(CLIENT, CallbackQuery(id="1", from_user=SOMEONE, message=business_message()))
+    assert not await filters.business(CLIENT, Message(id=1, chat=PRIVATE))
+
+
+@pytest.mark.asyncio
+async def test_linked_channel_reads_the_message_the_update_is_about():
+    forwarded = Message(id=1, chat=CHANNEL, **FROM_THE_LINKED_CHANNEL)
+
+    assert await filters.linked_channel(CLIENT, forwarded)
+    assert await filters.linked_channel(CLIENT, CallbackQuery(id="1", from_user=SOMEONE, message=forwarded))
+    assert not await filters.linked_channel(CLIENT, Message(id=1, chat=CHANNEL))
+
+
+@pytest.mark.asyncio
+async def test_topic_reads_the_message_the_update_is_about():
+    in_a_topic = Message(id=1, chat=PRIVATE, topic=A_TOPIC)
+
+    assert await filters.topic(13)(CLIENT, in_a_topic)
+    assert await filters.topic(13)(CLIENT, CallbackQuery(id="1", from_user=SOMEONE, message=in_a_topic))
+    assert not await filters.topic(1)(CLIENT, in_a_topic)
+    assert not await filters.topic(13)(CLIENT, Message(id=1, chat=PRIVATE))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("update", WITHOUT_A_CHAT)
+async def test_an_update_with_no_message_does_not_match_rather_than_raising(update):
+    """These three read a field that only `Message` has.
+
+    They used to take it off whatever the handler passed them, so a callback query or an
+    inline query answered with `AttributeError: 'CallbackQuery' object has no attribute
+    'business_connection_id'` instead of not matching.
+    """
+    assert not await filters.business(CLIENT, update)
+    assert not await filters.linked_channel(CLIENT, update)
+    assert not await filters.topic(13)(CLIENT, update)
 
 
 def test_callback_query_chat_follows_its_message():


### PR DESCRIPTION
Follow-up to #346. Closes up what's left in #175.

## What

#346 made twelve filters update-aware by taking the attribute off the update itself. Three were left behind — `business`, `linked_channel` and `topic` — because the fields they read (`business_connection_id`, `forward_origin`, `topic`) exist on `Message` and on no other update type, so there was nothing to add to the four tuples. They still read the attribute off whatever the handler hands them:

```python
query = CallbackQuery(id="1", from_user=User(id=42), message=Message(id=1))

await filters.business(client, query)
# AttributeError: 'CallbackQuery' object has no attribute 'business_connection_id'

await filters.linked_channel(client, query)
# AttributeError: 'CallbackQuery' object has no attribute 'forward_origin'

await filters.topic(13)(client, query)
# AttributeError: 'CallbackQuery' object has no attribute 'topic'
```

Since the field cannot come off the update, these three go through the message the update is about — a fifth helper beside the four already there:

```python
_WITH_A_MESSAGE = (CallbackQuery,)


def _message_of(update: Update) -> Optional[Message]:
    if isinstance(update, Message):
        return update

    return update.message if isinstance(update, _WITH_A_MESSAGE) else None
```

`CallbackQuery` is the only `Update` subclass that carries a message today, and the tuple is checked the same way the other four are: `test_the_filters_name_every_update_type_that_carries_the_field` gains a `("message", filters._WITH_A_MESSAGE)` row, so a new update type with a `message` cannot slip past unnoticed.

## Why the message rather than "does not apply"

Answering `False` on every non-message would also have removed the `AttributeError`, but it would be the wrong answer. For a business-connection callback the id lives on exactly that message — `CallbackQuery._parse` hands `connection_id` to `Message._parse` and keeps nothing on the query itself — so the message is the only place the answer exists. The same reasoning holds for `topic`: the button was pressed in the topic its message sits in.

An update that carries no message at all — an inline query, a poll, a callback on an inline message — does not match instead of raising, which is what #346 established for the other twelve.

## Scope

Behaviour on a `Message` is unchanged for all three. `topic.__call__` returns a real `bool` now; it used to return `message.topic and message.topic.id in self`, i.e. `None` for a message outside a topic. The docstrings say "updates" where they said "messages", matching the twelve from #346.

## How to test

```python
@app.on_callback_query(filters.business)
async def handler(client, callback_query): ...
```

On `dev` this raises `AttributeError: 'CallbackQuery' object has no attribute 'business_connection_id'` on every button press under a business message.

`tests/filters/test_update_attributes.py` gains 8 cases and `pytest tests` goes from 142 to 150. One of the 8 is the tuple-completeness row, which has nothing to compare against on `dev`; drop it and the other 7 all fail there — three filters on a callback query, and the four no-message updates raising instead of answering `False`.
