### PR TITLE
feat(errors): name the value each parameterised error carries

### DIFF
--- a/compiler/errors/compiler.py
+++ b/compiler/errors/compiler.py
@@ -127,22 +127,22 @@ def start():
 
                     f_all.write("        \"{}\": \"{}\",\n".format(error_id, sub_class))
 
-                    # NOTE: The placeholder in a message is what the value Telegram sends along
-                    #       with the error means, so it is also the name the error exposes it
-                    #       under. A message that still says "{value}" gets no property: `value` is
-                    #       the attribute itself, and a property of that name would shadow it.
+                    # The placeholder in a message is what the value Telegram sends along with
+                    # the error means, so it is also the name the error exposes it under. A
+                    # message that still says "{value}" gets no property: `value` is the
+                    # attribute itself, and a property of that name would shadow it.
                     #
-                    #       The names are Telegram's own words for each value, from the
-                    #       descriptions in https://corefork.telegram.org/api/errors.json, or the
-                    #       schema's word for the same thing (`dc_id` is `auth.exportAuthorization
-                    #       .dc_id`, `file_part` is `upload.saveFilePart.file_part`). Where
-                    #       Telethon already named one, the name is theirs:
-                    #       https://github.com/LonamiWebs/Telethon/blob/v1.36.0/telethon_generator/data/errors.csv
+                    # The names are Telegram's own words for each value, from the descriptions in
+                    # https://corefork.telegram.org/api/errors.json, or the schema's word for the
+                    # same thing (`dc_id` is `auth.exportAuthorization.dc_id`, `file_part` is
+                    # `upload.saveFilePart.file_part`). Where Telethon already named one, the name
+                    # is theirs:
+                    # https://github.com/LonamiWebs/Telethon/blob/v1.36.0/telethon_generator/data/errors.csv
                     #
-                    #       One placeholder per message, at most. `RPCError.raise_it()` reads a
-                    #       single number out of an error message and renders the message with it,
-                    #       so a second placeholder could never be filled in - `str.format()` would
-                    #       raise `KeyError` on the error nobody can catch.
+                    # One placeholder per message, at most. `RPCError.raise_it()` reads a single
+                    # number out of an error message and renders the message with it, so a second
+                    # placeholder could never be filled in - `str.format()` would raise `KeyError`
+                    # on the error nobody can catch.
                     placeholders = re.findall(r"\{(\w*)\}", error_message)
 
                     if len(placeholders) > 1:

--- a/compiler/errors/compiler.py
+++ b/compiler/errors/compiler.py
@@ -20,6 +20,8 @@ import csv
 import os
 import re
 import shutil
+from dataclasses import dataclass
+from typing import List
 
 HOME = "compiler/errors"
 DEST = "pyrogram/errors/exceptions"
@@ -37,7 +39,15 @@ def caml(s):
     return "".join([str(i.title()) for i in s])
 
 
-def value_property(template, value_name):
+@dataclass(frozen=True)
+class SubClass:
+    name: str
+    error_id: str
+    message: str
+    value_name: str
+
+
+def value_property(template: str, *, value_name: str) -> str:
     if value_name == "value":
         return ""
 
@@ -47,8 +57,8 @@ def value_property(template, value_name):
     return "\n\n" + template.format(value_name=value_name).rstrip("\n")
 
 
-def typing_import(sub_classes):
-    if all(k[3] == "value" for k in sub_classes):
+def typing_import(sub_classes: List[SubClass]) -> str:
+    if all(entry.value_name == "value" for entry in sub_classes):
         return ""
 
     return "from typing import Optional\n\n"
@@ -117,14 +127,37 @@ def start():
 
                     f_all.write("        \"{}\": \"{}\",\n".format(error_id, sub_class))
 
-                    # The placeholder in the message is what the value Telegram sends along with
-                    # the error means, so it is also the name the error exposes it under. A message
-                    # that still says "{value}" gets no property: `value` is already taken by the
-                    # attribute itself, and a property of the same name would shadow it.
-                    value_match = re.search(r"\{(\w+)\}", error_message)
-                    value_name = value_match.group(1) if value_match is not None else "value"
+                    # NOTE: The placeholder in a message is what the value Telegram sends along
+                    #       with the error means, so it is also the name the error exposes it
+                    #       under. A message that still says "{value}" gets no property: `value` is
+                    #       the attribute itself, and a property of that name would shadow it.
+                    #
+                    #       The names are Telegram's own words for each value, from the
+                    #       descriptions in https://corefork.telegram.org/api/errors.json, or the
+                    #       schema's word for the same thing (`dc_id` is `auth.exportAuthorization
+                    #       .dc_id`, `file_part` is `upload.saveFilePart.file_part`). Where
+                    #       Telethon already named one, the name is theirs:
+                    #       https://github.com/LonamiWebs/Telethon/blob/v1.36.0/telethon_generator/data/errors.csv
+                    #
+                    #       One placeholder per message, at most. `RPCError.raise_it()` reads a
+                    #       single number out of an error message and renders the message with it,
+                    #       so a second placeholder could never be filled in - `str.format()` would
+                    #       raise `KeyError` on the error nobody can catch.
+                    placeholders = re.findall(r"\{(\w*)\}", error_message)
 
-                    sub_classes.append((sub_class, error_id, error_message, value_name))
+                    if len(placeholders) > 1:
+                        raise ValueError("{} carries {} placeholders: {}".format(
+                            error_id, len(placeholders), error_message
+                        ))
+
+                    value_name = placeholders[0] if placeholders else "value"
+
+                    sub_classes.append(SubClass(
+                        name=sub_class,
+                        error_id=error_id,
+                        message=error_message,
+                        value_name=value_name
+                    ))
 
                 with open("{}/template/class.txt".format(HOME), "r", encoding="utf-8") as f_class_template:
                     class_template = f_class_template.read()
@@ -142,12 +175,15 @@ def start():
                         code=code,
                         docstring='"""{}"""'.format(name),
                         sub_classes="".join([sub_class_template.format(
-                            sub_class=k[0],
+                            sub_class=entry.name,
                             super_class=super_class,
-                            id="\"{}\"".format(k[1]),
-                            docstring='"""{}"""'.format(k[2]),
-                            value_property=value_property(value_property_template, k[3])
-                        ) for k in sub_classes])
+                            id="\"{}\"".format(entry.error_id),
+                            docstring='"""{}"""'.format(entry.message),
+                            value_property=value_property(
+                                value_property_template,
+                                value_name=entry.value_name
+                            )
+                        ) for entry in sub_classes])
                     )
 
                 f_class.write(class_template)

--- a/compiler/errors/compiler.py
+++ b/compiler/errors/compiler.py
@@ -37,6 +37,23 @@ def caml(s):
     return "".join([str(i.title()) for i in s])
 
 
+def value_property(template, value_name):
+    if value_name == "value":
+        return ""
+
+    # A blank line, then the block, appended to the `MESSAGE = __doc__` line the sub class template
+    # ends its body with. Spelled out here rather than left to whichever newlines the template file
+    # happens to begin and end with.
+    return "\n\n" + template.format(value_name=value_name).rstrip("\n")
+
+
+def typing_import(sub_classes):
+    if all(k[3] == "value" for k in sub_classes):
+        return ""
+
+    return "from typing import Optional\n\n"
+
+
 def start():
     shutil.rmtree(DEST, ignore_errors=True)
     os.makedirs(DEST)
@@ -104,8 +121,8 @@ def start():
                     # the error means, so it is also the name the error exposes it under. A message
                     # that still says "{value}" gets no property: `value` is already taken by the
                     # attribute itself, and a property of the same name would shadow it.
-                    value_name = re.search(r"\{(\w+)\}", error_message)
-                    value_name = value_name.group(1) if value_name is not None else "value"
+                    value_match = re.search(r"\{(\w+)\}", error_message)
+                    value_name = value_match.group(1) if value_match is not None else "value"
 
                     sub_classes.append((sub_class, error_id, error_message, value_name))
 
@@ -120,6 +137,7 @@ def start():
 
                     class_template = class_template.format(
                         notice=notice,
+                        typing_import=typing_import(sub_classes),
                         super_class=super_class,
                         code=code,
                         docstring='"""{}"""'.format(name),
@@ -128,7 +146,7 @@ def start():
                             super_class=super_class,
                             id="\"{}\"".format(k[1]),
                             docstring='"""{}"""'.format(k[2]),
-                            value_property="" if k[3] == "value" else value_property_template.format(value_name=k[3])
+                            value_property=value_property(value_property_template, k[3])
                         ) for k in sub_classes])
                     )
 

--- a/compiler/errors/compiler.py
+++ b/compiler/errors/compiler.py
@@ -100,13 +100,23 @@ def start():
 
                     f_all.write("        \"{}\": \"{}\",\n".format(error_id, sub_class))
 
-                    sub_classes.append((sub_class, error_id, error_message))
+                    # The placeholder in the message is what the value Telegram sends along with
+                    # the error means, so it is also the name the error exposes it under. A message
+                    # that still says "{value}" gets no property: `value` is already taken by the
+                    # attribute itself, and a property of the same name would shadow it.
+                    value_name = re.search(r"\{(\w+)\}", error_message)
+                    value_name = value_name.group(1) if value_name is not None else "value"
+
+                    sub_classes.append((sub_class, error_id, error_message, value_name))
 
                 with open("{}/template/class.txt".format(HOME), "r", encoding="utf-8") as f_class_template:
                     class_template = f_class_template.read()
 
                     with open("{}/template/sub_class.txt".format(HOME), "r", encoding="utf-8") as f_sub_class_template:
                         sub_class_template = f_sub_class_template.read()
+
+                    with open("{}/template/value_property.txt".format(HOME), "r", encoding="utf-8") as f_value_property_template:
+                        value_property_template = f_value_property_template.read()
 
                     class_template = class_template.format(
                         notice=notice,
@@ -117,7 +127,8 @@ def start():
                             sub_class=k[0],
                             super_class=super_class,
                             id="\"{}\"".format(k[1]),
-                            docstring='"""{}"""'.format(k[2])
+                            docstring='"""{}"""'.format(k[2]),
+                            value_property="" if k[3] == "value" else value_property_template.format(value_name=k[3])
                         ) for k in sub_classes])
                     )
 

--- a/compiler/errors/compiler.py
+++ b/compiler/errors/compiler.py
@@ -58,7 +58,7 @@ def value_property(template: str, *, value_name: str) -> str:
 
 
 def typing_import(sub_classes: List[SubClass]) -> str:
-    if all(entry.value_name == "value" for entry in sub_classes):
+    if all(sub_class.value_name == "value" for sub_class in sub_classes):
         return ""
 
     return "from typing import Optional\n\n"
@@ -121,11 +121,11 @@ def start():
 
                     error_id, error_message = row
 
-                    sub_class = caml(re.sub(r"_X", "_", error_id))
-                    sub_class = re.sub(r"^2", "Two", sub_class)
-                    sub_class = re.sub(r" ", "", sub_class)
+                    class_name = caml(re.sub(r"_X", "_", error_id))
+                    class_name = re.sub(r"^2", "Two", class_name)
+                    class_name = re.sub(r" ", "", class_name)
 
-                    f_all.write("        \"{}\": \"{}\",\n".format(error_id, sub_class))
+                    f_all.write("        \"{}\": \"{}\",\n".format(error_id, class_name))
 
                     # The placeholder in a message is what the value Telegram sends along with
                     # the error means, so it is also the name the error exposes it under. A
@@ -146,18 +146,19 @@ def start():
                     placeholders = re.findall(r"\{(\w*)\}", error_message)
 
                     if len(placeholders) > 1:
-                        raise ValueError("{} carries {} placeholders: {}".format(
-                            error_id, len(placeholders), error_message
-                        ))
+                        msg = "{} carries more than one placeholder: {}".format(error_id, error_message)
+                        raise ValueError(msg)
 
                     value_name = placeholders[0] if placeholders else "value"
 
-                    sub_classes.append(SubClass(
-                        name=sub_class,
+                    sub_class = SubClass(
+                        name=class_name,
                         error_id=error_id,
                         message=error_message,
                         value_name=value_name
-                    ))
+                    )
+
+                    sub_classes.append(sub_class)
 
                 with open("{}/template/class.txt".format(HOME), "r", encoding="utf-8") as f_class_template:
                     class_template = f_class_template.read()
@@ -175,15 +176,15 @@ def start():
                         code=code,
                         docstring='"""{}"""'.format(name),
                         sub_classes="".join([sub_class_template.format(
-                            sub_class=entry.name,
+                            sub_class=sub_class.name,
                             super_class=super_class,
-                            id="\"{}\"".format(entry.error_id),
-                            docstring='"""{}"""'.format(entry.message),
+                            id="\"{}\"".format(sub_class.error_id),
+                            docstring='"""{}"""'.format(sub_class.message),
                             value_property=value_property(
                                 value_property_template,
-                                value_name=entry.value_name
+                                value_name=sub_class.value_name
                             )
-                        ) for entry in sub_classes])
+                        ) for sub_class in sub_classes])
                     )
 
                 f_class.write(class_template)

--- a/compiler/errors/source/303_SEE_OTHER.tsv
+++ b/compiler/errors/source/303_SEE_OTHER.tsv
@@ -1,6 +1,6 @@
 id	message
-FILE_MIGRATE_X	The file to be accessed is currently stored in DC{value}.
-NETWORK_MIGRATE_X	The source IP address is associated with DC{value} (for registration).
-PHONE_MIGRATE_X	The phone number a user is trying to use for authorization is associated with DC{value}.
-STATS_MIGRATE_X	The statistics of the group/channel are stored in DC{value}.
-USER_MIGRATE_X	The user whose identity is being used to execute queries is associated with DC{value} (for registration).
+FILE_MIGRATE_X	The file to be accessed is currently stored in DC{dc_id}.
+NETWORK_MIGRATE_X	The source IP address is associated with DC{dc_id} (for registration).
+PHONE_MIGRATE_X	The phone number a user is trying to use for authorization is associated with DC{dc_id}.
+STATS_MIGRATE_X	The statistics of the group/channel are stored in DC{dc_id}.
+USER_MIGRATE_X	The user whose identity is being used to execute queries is associated with DC{dc_id} (for registration).

--- a/compiler/errors/source/400_BAD_REQUEST.tsv
+++ b/compiler/errors/source/400_BAD_REQUEST.tsv
@@ -15,7 +15,7 @@ AICOMPOSE_TONE_TITLE_INVALID	The specified tone title is invalid.
 AI_COMPOSE_TASK_MISSING	The text composition style is missing.
 ALBUM_PHOTOS_TOO_MANY	Too many photos were included in the album.
 ANONYMOUS_OPEN_INVALID	allow_adding_options is not supported for anonymous polls and quizzes.
-ANSWER_X_MEDIA_TYPE_INVALID	The option media type at index {value} is invalid.
+ANSWER_X_MEDIA_TYPE_INVALID	The option media type at index {index} is invalid.
 API_ID_INVALID	The api_id/api_hash combination is invalid.
 API_ID_PUBLISHED_FLOOD	You are using an API key that is limited on the server side because it was published somewhere.
 ARTICLE_TITLE_EMPTY	The title of the article is empty.
@@ -183,7 +183,7 @@ EMAIL_INVALID	The specified email is invalid.
 EMAIL_NOT_ALLOWED	The specified email cannot be used to complete the operation.
 EMAIL_NOT_SETUP	In order to change the login email with emailVerifyPurposeLoginChange, an existing login email must already be set using emailVerifyPurposeLoginSetup.
 EMAIL_UNCONFIRMED	Email unconfirmed.
-EMAIL_UNCONFIRMED_X	The provided email isn't confirmed, {value} is the length of the verification code that was just sent to the email: use [account.verifyEmail](https://core.telegram.org/method/account.verifyEmail) to enter the received verification code and enable the recovery email.
+EMAIL_UNCONFIRMED_X	The provided email isn't confirmed, {code_length} is the length of the verification code that was just sent to the email: use [account.verifyEmail](https://core.telegram.org/method/account.verifyEmail) to enter the received verification code and enable the recovery email.
 EMAIL_VERIFY_EXPIRED	The verification email has expired.
 EMOJI_INVALID	The specified theme emoji is valid.
 EMOJI_MARKUP_INVALID	The specified `video_emoji_markup` was invalid.
@@ -219,7 +219,7 @@ FIELD_NAME_INVALID	The field with the name FIELD_NAME is invalid.
 FILE_CONTENT_TYPE_INVALID	File content-type is invalid.
 FILE_EMTPY	An empty file was provided.
 FILE_ID_INVALID	The provided file id is invalid.
-FILE_MIGRATE_X	The file currently being accessed is stored in DC{value}, please re-send the query to that DC.
+FILE_MIGRATE_X	The file currently being accessed is stored in DC{dc_id}, please re-send the query to that DC.
 FILE_PARTS_INVALID	The number of file parts is invalid.
 FILE_PART_0_MISSING	File part 0 missing.
 FILE_PART_EMPTY	The provided file part is empty.
@@ -229,13 +229,13 @@ FILE_PART_SIZE_CHANGED	The part size is different from the size of one of the pr
 FILE_PART_SIZE_INVALID	The provided file part size is invalid.
 FILE_PART_TOO_BIG	The uploaded file part is too big.
 FILE_PART_TOO_SMALL	The size limit for the content of the file part has been exceeded.
-FILE_PART_X_MISSING	Part {value} of the file is missing from storage. Try repeating the method call to resave the part.
+FILE_PART_X_MISSING	Part {part_number} of the file is missing from storage. Try repeating the method call to resave the part.
 FILE_REFERENCE_EMPTY	The file id contains an empty [file reference](https://core.telegram.org/api/file_reference), you must obtain a valid one by fetching the message from the origin context.
 FILE_REFERENCE_EXPIRED	The file id contains an expired [file reference](https://core.telegram.org/api/file_reference), you must obtain a valid one by fetching the message from the origin context.
 FILE_REFERENCE_INVALID	The file id contains an invalid [file reference](https://core.telegram.org/api/file_reference), you must obtain a valid one by fetching the message from the origin context.
-FILE_REFERENCE_X_EMPTY	The file reference of the media file at offset {value} in the multi_media array is invalid.
-FILE_REFERENCE_X_EXPIRED	The [file reference](https://core.telegram.org/api/file_reference) of the media file at index {value} in the passed media array expired, it must be refreshed.
-FILE_REFERENCE_X_INVALID	The [file reference](https://core.telegram.org/api/file_reference) of the media file at index {value} in the passed media array is invalid.
+FILE_REFERENCE_X_EMPTY	The file reference of the media file at offset {index} in the multi_media array is invalid.
+FILE_REFERENCE_X_EXPIRED	The [file reference](https://core.telegram.org/api/file_reference) of the media file at index {index} in the passed media array expired, it must be refreshed.
+FILE_REFERENCE_X_INVALID	The [file reference](https://core.telegram.org/api/file_reference) of the media file at index {index} in the passed media array is invalid.
 FILE_TITLE_EMPTY	An empty file title was specified.
 FILE_TOKEN_INVALID	The master DC did not accept the `file_token` (e.g., the token has expired). Continue downloading the file from the master DC using upload.getFile.
 FILTER_ID_INVALID	The specified filter ID is invalid.
@@ -295,7 +295,7 @@ INLINE_RESULT_EXPIRED	The inline bot query expired.
 INPUT_CHATLIST_INVALID	The specified folder is invalid.
 INPUT_CONSTRUCTOR_INVALID	The specified TL constructor is invalid.
 INPUT_FETCH_ERROR	An error occurred while deserializing the provided TL constructor.
-INPUT_FETCH_ERROR_X	An error occurred while parsing the provided TL {value} constructor.
+INPUT_FETCH_ERROR_X	An error occurred while parsing the provided TL {constructor_id} constructor.
 INPUT_FETCH_FAIL	Failed deserializing TL payload.
 INPUT_FILE_INVALID	The specified [InputFile](https://core.telegram.org/type/InputFile) is invalid.
 INPUT_FILTER_INVALID	The specified filter is invalid.
@@ -405,7 +405,7 @@ PASSWORD_MISSING	You must [enable 2FA](https://core.telegram.org/api/srp) before
 PASSWORD_RECOVERY_EXPIRED	The recovery code has expired.
 PASSWORD_RECOVERY_NA	No email was set, can't recover password via email.
 PASSWORD_REQUIRED	The two-step verification password is required for this method.
-PASSWORD_TOO_FRESH_X	The two-step verification password was modified less than 24 hours ago, try again in {value} seconds.
+PASSWORD_TOO_FRESH_X	The two-step verification password was modified less than 24 hours ago, try again in {seconds} seconds.
 PAYMENT_CREDENTIALS_INVALID	The specified payment credentials are invalid.
 PAYMENT_PROVIDER_INVALID	The payment provider was not recognised or its token was invalid.
 PAYMENT_REQUIRED	The payment is required.
@@ -534,7 +534,7 @@ SEND_AS_PEER_INVALID	You can't send messages as the specified peer.
 SEND_MESSAGE_GAME_INVALID	An inputBotInlineMessageGame can only be contained in an inputBotInlineResultGame, not in an inputBotInlineResult/inputBotInlineResultPhoto/etc.
 SEND_MESSAGE_MEDIA_INVALID	The message media is invalid.
 SEND_MESSAGE_TYPE_INVALID	The message type is invalid.
-SESSION_TOO_FRESH_X	This session was created less than 24 hours ago, try again in {value} seconds.
+SESSION_TOO_FRESH_X	This session was created less than 24 hours ago, try again in {seconds} seconds.
 SETTINGS_INVALID	Invalid settings were provided.
 SHA256_HASH_INVALID	The provided SHA256 hash is invalid.
 SHORTCUT_INVALID	The specified shortcut is invalid.
@@ -571,9 +571,9 @@ STARGIFT_OWNER_INVALID	The specified gift owner is invalid.
 STARGIFT_PEER_INVALID	The specified inputSavedStarGiftChat.peer is invalid.
 STARGIFT_RESELL_CURRENCY_NOT_ALLOWED	The currency provided for gift resell is not allowed.
 STARGIFT_RESELL_NOT_ALLOWED	You can't buy this gift. Someone else may have already bought it or this gift is not for sale.
-STARGIFT_RESELL_TOO_EARLY_X	A wait of {value} seconds is required to resell this gift.
+STARGIFT_RESELL_TOO_EARLY_X	A wait of {seconds} seconds is required to resell this gift.
 STARGIFT_SLUG_INVALID	The provided star gift slug is invalid (must match the format CollectionName-123).
-STARGIFT_TRANSFER_TOO_EARLY_X	A wait of {value} seconds is required to transfer this gift.
+STARGIFT_TRANSFER_TOO_EARLY_X	A wait of {seconds} seconds is required to transfer this gift.
 STARGIFT_UPGRADE_UNAVAILABLE	Gift is not available for upgrade yet.
 STARGIFT_USAGE_LIMITED	The gift is sold out.
 STARGIFT_USER_USAGE_LIMITED	You've reached the starGift.limited_per_user limit, you can't buy any more gifts of this type.
@@ -616,12 +616,12 @@ STORIES_NEVER_CREATED	This peer hasn't ever posted any stories.
 STORIES_TOO_MUCH	You have hit the maximum active stories limit as specified by the [`story_expiring_limit_*` client configuration parameters](https://core.telegram.org/api/config#story-expiring-limit-default): you should buy a [Premium](https://core.telegram.org/api/premium) subscription, delete an active story, or wait for the oldest story to expire.
 STORY_ID_EMPTY	You specified no story IDs.
 STORY_ID_INVALID	The specified story ID is invalid.
-STORY_LIVE_ALREADY_X	The user or the chat has an active live story with identifier {value}.
+STORY_LIVE_ALREADY_X	The user or the chat has an active live story with identifier {story_id}.
 STORY_NOT_MODIFIED	The new story information you passed is equal to the previous story information, thus it wasn't modified.
 STORY_PERIOD_INVALID	The specified story period is invalid for this account.
 STORY_PUBLIC_MISSING	The story you are trying to access or manipulate is not publicly available.
-STORY_SEND_FLOOD_MONTHLY_X	You've hit the monthly story limit as specified by the [`stories_sent_monthly_limit_*` client configuration parameters](https://core.telegram.org/api/config#stories-sent-monthly-limit-default): wait {value} seconds before posting a new story.
-STORY_SEND_FLOOD_WEEKLY_X	You've hit the weekly story limit as specified by the [`stories_sent_weekly_limit_*` client configuration parameters](https://core.telegram.org/api/config#stories-sent-weekly-limit-default): wait {value} seconds before posting a new story.
+STORY_SEND_FLOOD_MONTHLY_X	You've hit the monthly story limit as specified by the [`stories_sent_monthly_limit_*` client configuration parameters](https://core.telegram.org/api/config#stories-sent-monthly-limit-default): wait {seconds} seconds before posting a new story.
+STORY_SEND_FLOOD_WEEKLY_X	You've hit the weekly story limit as specified by the [`stories_sent_weekly_limit_*` client configuration parameters](https://core.telegram.org/api/config#stories-sent-weekly-limit-default): wait {seconds} seconds before posting a new story.
 SUBSCRIPTION_EXPORT_MISSING	You cannot send a [bot subscription invoice](https://core.telegram.org/api/subscriptions#bot-subscriptions) directly, you may only create invoice links using [payments.exportInvoice](https://core.telegram.org/method/payments.exportInvoice).
 SUBSCRIPTION_ID_INVALID	The specified subscription_id is invalid.
 SUBSCRIPTION_PERIOD_INVALID	The specified subscription_pricing.period is invalid.

--- a/compiler/errors/source/400_BAD_REQUEST.tsv
+++ b/compiler/errors/source/400_BAD_REQUEST.tsv
@@ -229,7 +229,7 @@ FILE_PART_SIZE_CHANGED	The part size is different from the size of one of the pr
 FILE_PART_SIZE_INVALID	The provided file part size is invalid.
 FILE_PART_TOO_BIG	The uploaded file part is too big.
 FILE_PART_TOO_SMALL	The size limit for the content of the file part has been exceeded.
-FILE_PART_X_MISSING	Part {part_number} of the file is missing from storage. Try repeating the method call to resave the part.
+FILE_PART_X_MISSING	Part {file_part} of the file is missing from storage. Try repeating the method call to resave the part.
 FILE_REFERENCE_EMPTY	The file id contains an empty [file reference](https://core.telegram.org/api/file_reference), you must obtain a valid one by fetching the message from the origin context.
 FILE_REFERENCE_EXPIRED	The file id contains an expired [file reference](https://core.telegram.org/api/file_reference), you must obtain a valid one by fetching the message from the origin context.
 FILE_REFERENCE_INVALID	The file id contains an invalid [file reference](https://core.telegram.org/api/file_reference), you must obtain a valid one by fetching the message from the origin context.
@@ -295,7 +295,7 @@ INLINE_RESULT_EXPIRED	The inline bot query expired.
 INPUT_CHATLIST_INVALID	The specified folder is invalid.
 INPUT_CONSTRUCTOR_INVALID	The specified TL constructor is invalid.
 INPUT_FETCH_ERROR	An error occurred while deserializing the provided TL constructor.
-INPUT_FETCH_ERROR_X	An error occurred while parsing the provided TL {constructor_id} constructor.
+INPUT_FETCH_ERROR_X	An error occurred while parsing the provided TL {value} constructor.
 INPUT_FETCH_FAIL	Failed deserializing TL payload.
 INPUT_FILE_INVALID	The specified [InputFile](https://core.telegram.org/type/InputFile) is invalid.
 INPUT_FILTER_INVALID	The specified filter is invalid.

--- a/compiler/errors/source/403_FORBIDDEN.tsv
+++ b/compiler/errors/source/403_FORBIDDEN.tsv
@@ -1,6 +1,6 @@
 id	message
 ACCESS_DENIED	You cannot perform this request.
-ALLOW_PAYMENT_REQUIRED_X	The user has enabled paid messages with {value} stars.
+ALLOW_PAYMENT_REQUIRED_X	The user has enabled paid messages with {star_count} stars.
 ANONYMOUS_REACTIONS_DISABLED	Sorry, anonymous administrators cannot leave reactions or participate in polls.
 BOT_ACCESS_FORBIDDEN	You can't access this bot.
 BOT_FORUM_CREATE_FORBIDDEN	This bot prevents users from creating or deleting topics.

--- a/compiler/errors/source/406_NOT_ACCEPTABLE.tsv
+++ b/compiler/errors/source/406_NOT_ACCEPTABLE.tsv
@@ -25,7 +25,7 @@ POLL_COUNTRY_RESTRICTED	Users from the current user's country cannot vote in thi
 POLL_MEMBER_RESTRICTED	Only channel subscribers can vote in this poll.
 PRECHECKOUT_FAILED	Precheckout is failed.
 PREMIUM_CURRENTLY_UNAVAILABLE	You cannot currently purchase a Premium subscription.
-PREVIOUS_CHAT_IMPORT_ACTIVE_WAIT_XMIN	Import for this chat is already in progress, wait {value} minutes before starting a new one.
+PREVIOUS_CHAT_IMPORT_ACTIVE_WAIT_XMIN	Import for this chat is already in progress, wait {minutes} minutes before starting a new one.
 PRIVACY_PREMIUM_REQUIRED	You need a [Telegram Premium subscription](https://core.telegram.org/api/premium) to send a message to this user.
 SEND_CODE_UNAVAILABLE	Returned when all available options for this type of number were already used (e.g. flash-call, then SMS, then this error might be returned to trigger a second resend).
 STARGIFT_EXPORT_IN_PROGRESS	You can't send this gift at the moment as the withdrawal process to the blockchain has already started.

--- a/compiler/errors/source/420_FLOOD.tsv
+++ b/compiler/errors/source/420_FLOOD.tsv
@@ -1,11 +1,11 @@
 id	message
-2FA_CONFIRM_WAIT_X	A wait of {value} seconds is required because this account is active and protected by a 2FA password.
+2FA_CONFIRM_WAIT_X	A wait of {seconds} seconds is required because this account is active and protected by a 2FA password.
 ADDRESS_INVALID	The specified geopoint address is invalid.
-FLOOD_PREMIUM_WAIT_X	Please wait {value} seconds before repeating the action, or purchase a [Telegram Premium subscription](https://core.telegram.org/api/premium) to remove this rate limit.
-FLOOD_TEST_PHONE_WAIT_X	A wait of {value} seconds is required in the test servers.
-FLOOD_WAIT_X	Please wait {value} seconds before repeating the action.
+FLOOD_PREMIUM_WAIT_X	Please wait {seconds} seconds before repeating the action, or purchase a [Telegram Premium subscription](https://core.telegram.org/api/premium) to remove this rate limit.
+FLOOD_TEST_PHONE_WAIT_X	A wait of {seconds} seconds is required in the test servers.
+FLOOD_WAIT_X	Please wait {seconds} seconds before repeating the action.
 FROZEN_METHOD_INVALID	The method can't be used by frozen account. You can appeal via @SpamBot if you believe this was a mistake.
-PREMIUM_SUB_ACTIVE_UNTIL_X	You already have a premium subscription active until unixtime {value}.
-SLOWMODE_WAIT_X	Slowmode is enabled in this chat: wait {value} seconds before sending another message to this chat.
-STORY_SEND_FLOOD_X	A wait of {value} seconds is required to continue posting stories.
-TAKEOUT_INIT_DELAY_X	Sorry, for security reasons, you will be able to begin downloading your data in {value} seconds. We have notified all your devices about the export request to make sure it's authorized and to give you time to react if it's not.
+PREMIUM_SUB_ACTIVE_UNTIL_X	You already have a premium subscription active until unixtime {until_date}.
+SLOWMODE_WAIT_X	Slowmode is enabled in this chat: wait {seconds} seconds before sending another message to this chat.
+STORY_SEND_FLOOD_X	A wait of {seconds} seconds is required to continue posting stories.
+TAKEOUT_INIT_DELAY_X	Sorry, for security reasons, you will be able to begin downloading your data in {seconds} seconds. We have notified all your devices about the export request to make sure it's authorized and to give you time to react if it's not.

--- a/compiler/errors/source/500_INTERNAL_SERVER_ERROR.tsv
+++ b/compiler/errors/source/500_INTERNAL_SERVER_ERROR.tsv
@@ -2,7 +2,7 @@ id	message
 API_CALL_ERROR	API call error due to Telegram having internal problems. Please try again later.
 AUTH_KEY_UNSYNCHRONIZED	Internal error, please repeat the method call.
 AUTH_RESTART	User authorization has restarted.
-AUTH_RESTART_X	Internal error (debug info {debug_code}), please repeat the method call.
+AUTH_RESTART_X	Internal error (debug info {debug_info}), please repeat the method call.
 CALL_OCCUPY_FAILED	The call failed because the user is already making another call.
 CDN_UPLOAD_TIMEOUT	A server-side timeout occurred while reuploading the file to the CDN DC.
 CHAT_ID_GENERATE_FAILED	Failure while generating the chat ID.

--- a/compiler/errors/source/500_INTERNAL_SERVER_ERROR.tsv
+++ b/compiler/errors/source/500_INTERNAL_SERVER_ERROR.tsv
@@ -2,7 +2,7 @@ id	message
 API_CALL_ERROR	API call error due to Telegram having internal problems. Please try again later.
 AUTH_KEY_UNSYNCHRONIZED	Internal error, please repeat the method call.
 AUTH_RESTART	User authorization has restarted.
-AUTH_RESTART_X	Internal error (debug info {value}), please repeat the method call.
+AUTH_RESTART_X	Internal error (debug info {debug_code}), please repeat the method call.
 CALL_OCCUPY_FAILED	The call failed because the user is already making another call.
 CDN_UPLOAD_TIMEOUT	A server-side timeout occurred while reuploading the file to the CDN DC.
 CHAT_ID_GENERATE_FAILED	Failure while generating the chat ID.
@@ -19,8 +19,8 @@ GROUPCALL_ADD_PARTICIPANTS_FAILED	Failure while adding voice chat member due to 
 GROUPED_ID_OCCUPY_FAILED	Telegram is having internal problems. Please try again later.
 HISTORY_GET_FAILED	The chat history couldn't be retrieved due to Telegram having internal problems. Please try again later.
 IMAGE_ENGINE_DOWN	Image engine down due to Telegram having internal problems. Please try again later.
-INTERDC_X_CALL_ERROR	An error occurred while Telegram was intercommunicating with DC{value}. Please try again later.
-INTERDC_X_CALL_RICH_ERROR	A rich error occurred while Telegram was intercommunicating with DC{value}. Please try again later.
+INTERDC_X_CALL_ERROR	An error occurred while Telegram was intercommunicating with DC{dc_id}. Please try again later.
+INTERDC_X_CALL_RICH_ERROR	A rich error occurred while Telegram was intercommunicating with DC{dc_id}. Please try again later.
 MEMBER_FETCH_FAILED	Telegram is having internal problems. Please try again later.
 MEMBER_NO_LOCATION	Couldn't find the member's location due to Telegram having internal problems. Please try again later.
 MEMBER_OCCUPY_PRIMARY_LOC_FAILED	Telegram is having internal problems. Please try again later.

--- a/compiler/errors/template/class.txt
+++ b/compiler/errors/template/class.txt
@@ -1,6 +1,6 @@
 {notice}
 
-from ..rpc_error import RPCError
+{typing_import}from ..rpc_error import RPCError
 
 
 class {super_class}(RPCError):

--- a/compiler/errors/template/sub_class.txt
+++ b/compiler/errors/template/sub_class.txt
@@ -2,6 +2,6 @@ class {sub_class}({super_class}):
     {docstring}
     ID = {id}
     """``str``: RPC Error ID"""
-    MESSAGE = __doc__
+    MESSAGE = __doc__{value_property}
 
 

--- a/compiler/errors/template/value_property.txt
+++ b/compiler/errors/template/value_property.txt
@@ -1,0 +1,8 @@
+
+    VALUE_NAME = "{value_name}"
+    """``str``: Name of the property that holds this error's value"""
+
+    @property
+    def {value_name}(self) -> int:
+        """``int``: The value Telegram sent along with this error"""
+        return self.value

--- a/compiler/errors/template/value_property.txt
+++ b/compiler/errors/template/value_property.txt
@@ -3,5 +3,5 @@
 
     @property
     def {value_name}(self) -> Optional[int]:
-        """``Optional[int]``: Same as `value`, under the name this error's message gives it"""
+        """``Optional[int]``: What Telegram sent with this error, under the name its message gives it"""
         return self.value

--- a/compiler/errors/template/value_property.txt
+++ b/compiler/errors/template/value_property.txt
@@ -1,8 +1,7 @@
-
     VALUE_NAME = "{value_name}"
     """``str``: Name of the property that holds this error's value"""
 
     @property
-    def {value_name}(self) -> int:
-        """``int``: The value Telegram sent along with this error"""
+    def {value_name}(self) -> Optional[int]:
+        """``Optional[int]``: Same as `value`, under the name this error's message gives it"""
         return self.value

--- a/pyrogram/errors/rpc_error.py
+++ b/pyrogram/errors/rpc_error.py
@@ -31,6 +31,7 @@ class RPCError(Exception):
     CODE = None
     NAME = None
     MESSAGE = "{value}"
+    VALUE_NAME = "value"
 
     def __init__(
         self,
@@ -43,7 +44,7 @@ class RPCError(Exception):
             "-" if is_signed else "",
             self.CODE,
             self.ID or self.NAME,
-            self.MESSAGE.format(value=value),
+            self.MESSAGE.format(**{self.VALUE_NAME: value}),
             f'(caused by "{rpc_name}")' if rpc_name else ""
         ))
 

--- a/pyrogram/methods/account/add_profile_audio.py
+++ b/pyrogram/methods/account/add_profile_audio.py
@@ -144,7 +144,7 @@ class AddProfileAudio:
                 try:
                     r = await self.invoke(raw.functions.account.SaveMusic(id=media))
                 except FilePartMissing as e:
-                    await self.save_file(audio, file_id=file.id, file_part=e.part_number)
+                    await self.save_file(audio, file_id=file.id, file_part=e.file_part)
                 else:
                     return r
         except StopTransmission:

--- a/pyrogram/methods/account/add_profile_audio.py
+++ b/pyrogram/methods/account/add_profile_audio.py
@@ -144,7 +144,7 @@ class AddProfileAudio:
                 try:
                     r = await self.invoke(raw.functions.account.SaveMusic(id=media))
                 except FilePartMissing as e:
-                    await self.save_file(audio, file_id=file.id, file_part=e.value)
+                    await self.save_file(audio, file_id=file.id, file_part=e.part_number)
                 else:
                     return r
         except StopTransmission:

--- a/pyrogram/methods/auth/send_phone_number_code.py
+++ b/pyrogram/methods/auth/send_phone_number_code.py
@@ -166,18 +166,18 @@ class SendPhoneNumberCode:
 
                 r = await self.invoke(rpc, recaptcha_token=recaptcha_token)
             except (PhoneMigrate, NetworkMigrate) as e:
-                dc_option = await self.get_dc_option(e.value, ipv6=self.ipv6)
+                dc_option = await self.get_dc_option(e.dc_id, ipv6=self.ipv6)
                 await self.session.stop()
 
                 self.session = await self.get_session(
-                    dc_id=e.value,
+                    dc_id=e.dc_id,
                     server_address=dc_option.ip_address,
                     port=dc_option.port,
                     export_authorization=False,
                     temporary=True,
                 )
 
-                await self.storage.dc_id(e.value)
+                await self.storage.dc_id(e.dc_id)
                 await self.storage.server_address(dc_option.ip_address)
                 await self.storage.port(dc_option.port)
                 await self.storage.auth_key(self.session.auth_key)

--- a/pyrogram/methods/auth/sign_in_bot.py
+++ b/pyrogram/methods/auth/sign_in_bot.py
@@ -56,18 +56,18 @@ class SignInBot:
                     )
                 )
             except UserMigrate as e:
-                dc_option = await self.get_dc_option(e.value, ipv6=self.ipv6)
+                dc_option = await self.get_dc_option(e.dc_id, ipv6=self.ipv6)
                 await self.session.stop()
 
                 self.session = await self.get_session(
-                    dc_id=e.value,
+                    dc_id=e.dc_id,
                     server_address=dc_option.ip_address,
                     port=dc_option.port,
                     export_authorization=False,
                     temporary=True
                 )
 
-                await self.storage.dc_id(e.value)
+                await self.storage.dc_id(e.dc_id)
                 await self.storage.server_address(dc_option.ip_address)
                 await self.storage.port(dc_option.port)
                 await self.storage.auth_key(self.session.auth_key)

--- a/pyrogram/methods/messages/send_animation.py
+++ b/pyrogram/methods/messages/send_animation.py
@@ -378,7 +378,7 @@ class SendAnimation:
 
                     r = await self.invoke(rpc, business_connection_id=business_connection_id)
                 except FilePartMissing as e:
-                    await self.save_file(animation, file_id=file.id, file_part=e.value)
+                    await self.save_file(animation, file_id=file.id, file_part=e.part_number)
                 else:
                     for i in r.updates:
                         if isinstance(i, (raw.types.UpdateNewMessage,

--- a/pyrogram/methods/messages/send_animation.py
+++ b/pyrogram/methods/messages/send_animation.py
@@ -378,7 +378,7 @@ class SendAnimation:
 
                     r = await self.invoke(rpc, business_connection_id=business_connection_id)
                 except FilePartMissing as e:
-                    await self.save_file(animation, file_id=file.id, file_part=e.part_number)
+                    await self.save_file(animation, file_id=file.id, file_part=e.file_part)
                 else:
                     for i in r.updates:
                         if isinstance(i, (raw.types.UpdateNewMessage,

--- a/pyrogram/methods/messages/send_audio.py
+++ b/pyrogram/methods/messages/send_audio.py
@@ -366,7 +366,7 @@ class SendAudio:
 
                     r = await self.invoke(rpc, business_connection_id=business_connection_id)
                 except FilePartMissing as e:
-                    await self.save_file(audio, file_id=file.id, file_part=e.value)
+                    await self.save_file(audio, file_id=file.id, file_part=e.part_number)
                 else:
                     messages = await utils.parse_messages(client=self, messages=r)
 

--- a/pyrogram/methods/messages/send_audio.py
+++ b/pyrogram/methods/messages/send_audio.py
@@ -366,7 +366,7 @@ class SendAudio:
 
                     r = await self.invoke(rpc, business_connection_id=business_connection_id)
                 except FilePartMissing as e:
-                    await self.save_file(audio, file_id=file.id, file_part=e.part_number)
+                    await self.save_file(audio, file_id=file.id, file_part=e.file_part)
                 else:
                     messages = await utils.parse_messages(client=self, messages=r)
 

--- a/pyrogram/methods/messages/send_document.py
+++ b/pyrogram/methods/messages/send_document.py
@@ -338,7 +338,7 @@ class SendDocument:
 
                     r = await self.invoke(rpc, business_connection_id=business_connection_id)
                 except FilePartMissing as e:
-                    await self.save_file(document, file_id=file.id, file_part=e.value)
+                    await self.save_file(document, file_id=file.id, file_part=e.part_number)
                 else:
                     messages = await utils.parse_messages(client=self, messages=r)
 

--- a/pyrogram/methods/messages/send_document.py
+++ b/pyrogram/methods/messages/send_document.py
@@ -338,7 +338,7 @@ class SendDocument:
 
                     r = await self.invoke(rpc, business_connection_id=business_connection_id)
                 except FilePartMissing as e:
-                    await self.save_file(document, file_id=file.id, file_part=e.part_number)
+                    await self.save_file(document, file_id=file.id, file_part=e.file_part)
                 else:
                     messages = await utils.parse_messages(client=self, messages=r)
 

--- a/pyrogram/methods/messages/send_live_photo.py
+++ b/pyrogram/methods/messages/send_live_photo.py
@@ -272,7 +272,7 @@ class SendLivePhoto:
 
                     r = await self.invoke(rpc, business_connection_id=business_connection_id)
                 except FilePartMissing as e:
-                    await self.save_file(live_photo, file_id=file.id, file_part=e.value)
+                    await self.save_file(live_photo, file_id=file.id, file_part=e.part_number)
                 else:
                     messages = await utils.parse_messages(client=self, messages=r)
 

--- a/pyrogram/methods/messages/send_live_photo.py
+++ b/pyrogram/methods/messages/send_live_photo.py
@@ -272,7 +272,7 @@ class SendLivePhoto:
 
                     r = await self.invoke(rpc, business_connection_id=business_connection_id)
                 except FilePartMissing as e:
-                    await self.save_file(live_photo, file_id=file.id, file_part=e.part_number)
+                    await self.save_file(live_photo, file_id=file.id, file_part=e.file_part)
                 else:
                     messages = await utils.parse_messages(client=self, messages=r)
 

--- a/pyrogram/methods/messages/send_photo.py
+++ b/pyrogram/methods/messages/send_photo.py
@@ -336,7 +336,7 @@ class SendPhoto:
 
                     r = await self.invoke(rpc, business_connection_id=business_connection_id)
                 except FilePartMissing as e:
-                    await self.save_file(photo, file_id=file.id, file_part=e.part_number)
+                    await self.save_file(photo, file_id=file.id, file_part=e.file_part)
                 else:
                     messages = await utils.parse_messages(client=self, messages=r)
 

--- a/pyrogram/methods/messages/send_photo.py
+++ b/pyrogram/methods/messages/send_photo.py
@@ -336,7 +336,7 @@ class SendPhoto:
 
                     r = await self.invoke(rpc, business_connection_id=business_connection_id)
                 except FilePartMissing as e:
-                    await self.save_file(photo, file_id=file.id, file_part=e.value)
+                    await self.save_file(photo, file_id=file.id, file_part=e.part_number)
                 else:
                     messages = await utils.parse_messages(client=self, messages=r)
 

--- a/pyrogram/methods/messages/send_sticker.py
+++ b/pyrogram/methods/messages/send_sticker.py
@@ -322,7 +322,7 @@ class SendSticker:
 
                     r = await self.invoke(rpc, business_connection_id=business_connection_id)
                 except FilePartMissing as e:
-                    await self.save_file(sticker, file_id=file.id, file_part=e.value)
+                    await self.save_file(sticker, file_id=file.id, file_part=e.part_number)
                 else:
                     messages = await utils.parse_messages(client=self, messages=r)
 

--- a/pyrogram/methods/messages/send_sticker.py
+++ b/pyrogram/methods/messages/send_sticker.py
@@ -322,7 +322,7 @@ class SendSticker:
 
                     r = await self.invoke(rpc, business_connection_id=business_connection_id)
                 except FilePartMissing as e:
-                    await self.save_file(sticker, file_id=file.id, file_part=e.part_number)
+                    await self.save_file(sticker, file_id=file.id, file_part=e.file_part)
                 else:
                     messages = await utils.parse_messages(client=self, messages=r)
 

--- a/pyrogram/methods/messages/send_video.py
+++ b/pyrogram/methods/messages/send_video.py
@@ -467,7 +467,7 @@ class SendVideo:
 
                     r = await self.invoke(rpc, business_connection_id=business_connection_id)
                 except FilePartMissing as e:
-                    await self.save_file(video, file_id=file.id, file_part=e.value)
+                    await self.save_file(video, file_id=file.id, file_part=e.part_number)
                 else:
                     messages = await utils.parse_messages(client=self, messages=r)
 

--- a/pyrogram/methods/messages/send_video.py
+++ b/pyrogram/methods/messages/send_video.py
@@ -467,7 +467,7 @@ class SendVideo:
 
                     r = await self.invoke(rpc, business_connection_id=business_connection_id)
                 except FilePartMissing as e:
-                    await self.save_file(video, file_id=file.id, file_part=e.part_number)
+                    await self.save_file(video, file_id=file.id, file_part=e.file_part)
                 else:
                     messages = await utils.parse_messages(client=self, messages=r)
 

--- a/pyrogram/methods/messages/send_video_note.py
+++ b/pyrogram/methods/messages/send_video_note.py
@@ -355,7 +355,7 @@ class SendVideoNote:
 
                     r = await self.invoke(rpc, business_connection_id=business_connection_id)
                 except FilePartMissing as e:
-                    await self.save_file(video_note, file_id=file.id, file_part=e.value)
+                    await self.save_file(video_note, file_id=file.id, file_part=e.part_number)
                 else:
                     messages = await utils.parse_messages(client=self, messages=r)
 

--- a/pyrogram/methods/messages/send_video_note.py
+++ b/pyrogram/methods/messages/send_video_note.py
@@ -355,7 +355,7 @@ class SendVideoNote:
 
                     r = await self.invoke(rpc, business_connection_id=business_connection_id)
                 except FilePartMissing as e:
-                    await self.save_file(video_note, file_id=file.id, file_part=e.part_number)
+                    await self.save_file(video_note, file_id=file.id, file_part=e.file_part)
                 else:
                     messages = await utils.parse_messages(client=self, messages=r)
 

--- a/pyrogram/methods/messages/send_voice.py
+++ b/pyrogram/methods/messages/send_voice.py
@@ -344,7 +344,7 @@ class SendVoice:
 
                     r = await self.invoke(rpc, business_connection_id=business_connection_id)
                 except FilePartMissing as e:
-                    await self.save_file(voice, file_id=file.id, file_part=e.part_number)
+                    await self.save_file(voice, file_id=file.id, file_part=e.file_part)
                 else:
                     messages = await utils.parse_messages(client=self, messages=r)
 

--- a/pyrogram/methods/messages/send_voice.py
+++ b/pyrogram/methods/messages/send_voice.py
@@ -344,7 +344,7 @@ class SendVoice:
 
                     r = await self.invoke(rpc, business_connection_id=business_connection_id)
                 except FilePartMissing as e:
-                    await self.save_file(voice, file_id=file.id, file_part=e.value)
+                    await self.save_file(voice, file_id=file.id, file_part=e.part_number)
                 else:
                     messages = await utils.parse_messages(client=self, messages=r)
 

--- a/pyrogram/methods/stories/edit_story_media.py
+++ b/pyrogram/methods/stories/edit_story_media.py
@@ -161,7 +161,7 @@ class EditStoryMedia:
                         )
                     )
                 except FilePartMissing as e:
-                    await self.save_file(media, file_id=file.id, file_part=e.value)
+                    await self.save_file(media, file_id=file.id, file_part=e.part_number)
                 else:
                     for i in r.updates:
                         if isinstance(i, raw.types.UpdateStory):

--- a/pyrogram/methods/stories/edit_story_media.py
+++ b/pyrogram/methods/stories/edit_story_media.py
@@ -161,7 +161,7 @@ class EditStoryMedia:
                         )
                     )
                 except FilePartMissing as e:
-                    await self.save_file(media, file_id=file.id, file_part=e.part_number)
+                    await self.save_file(media, file_id=file.id, file_part=e.file_part)
                 else:
                     for i in r.updates:
                         if isinstance(i, raw.types.UpdateStory):

--- a/pyrogram/methods/stories/send_story.py
+++ b/pyrogram/methods/stories/send_story.py
@@ -261,7 +261,7 @@ class SendStory:
                         )
                     )
                 except FilePartMissing as e:
-                    await self.save_file(media, file_id=file.id, file_part=e.value)
+                    await self.save_file(media, file_id=file.id, file_part=e.part_number)
                 else:
                     for i in r.updates:
                         if isinstance(i, raw.types.UpdateStory):

--- a/pyrogram/methods/stories/send_story.py
+++ b/pyrogram/methods/stories/send_story.py
@@ -261,7 +261,7 @@ class SendStory:
                         )
                     )
                 except FilePartMissing as e:
-                    await self.save_file(media, file_id=file.id, file_part=e.part_number)
+                    await self.save_file(media, file_id=file.id, file_part=e.file_part)
                 else:
                     for i in r.updates:
                         if isinstance(i, raw.types.UpdateStory):

--- a/pyrogram/session/session.py
+++ b/pyrogram/session/session.py
@@ -550,7 +550,7 @@ class Session:
             try:
                 return await self.send(query, timeout=timeout)
             except (FloodWait, FloodPremiumWait) as e:
-                amount = e.value
+                amount = e.seconds
 
                 if amount > sleep_threshold >= 0:
                     raise

--- a/tests/errors/__init__.py
+++ b/tests/errors/__init__.py
@@ -1,0 +1,18 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+

--- a/tests/errors/__init__.py
+++ b/tests/errors/__init__.py
@@ -16,3 +16,16 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Final
+
+from pyrogram import raw
+from pyrogram.errors import RPCError
+
+RPC_NAME: Final[str] = "messages.GetHistory"
+
+
+def raise_it(code: int, *, message: str) -> None:
+    RPCError.raise_it(
+        raw.types.RpcError(error_code=code, error_message=message),
+        raw.functions.messages.GetHistory
+    )

--- a/tests/errors/test_named_values.py
+++ b/tests/errors/test_named_values.py
@@ -1,0 +1,121 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from importlib import import_module
+
+import pytest
+
+from pyrogram import raw
+from pyrogram.errors import (
+    FilePartMissing,
+    FloodWait,
+    PeerIdInvalid,
+    PhoneMigrate,
+    PremiumSubActiveUntil,
+    PreviousChatImportActiveWaitMin,
+    RPCError
+)
+from pyrogram.errors.exceptions.all import exceptions
+
+
+def raise_it(code, *, message):
+    RPCError.raise_it(
+        raw.types.RpcError(error_code=code, error_message=message),
+        raw.functions.messages.GetHistory
+    )
+
+
+@pytest.mark.parametrize(
+    ("code", "message", "error_type", "value_name", "value"),
+    [
+        pytest.param(420, "FLOOD_WAIT_42", FloodWait, "seconds", 42, id="seconds"),
+        pytest.param(303, "PHONE_MIGRATE_2", PhoneMigrate, "dc_id", 2, id="dc-id"),
+        pytest.param(400, "FILE_PART_3_MISSING", FilePartMissing, "part_number", 3, id="part-number"),
+        pytest.param(
+            406,
+            "PREVIOUS_CHAT_IMPORT_ACTIVE_WAIT_5MIN",
+            PreviousChatImportActiveWaitMin,
+            "minutes",
+            5,
+            id="minutes"
+        ),
+        pytest.param(
+            420,
+            "PREMIUM_SUB_ACTIVE_UNTIL_1755561600",
+            PremiumSubActiveUntil,
+            "until_date",
+            1755561600,
+            id="until-date"
+        )
+    ]
+)
+def test_an_error_says_what_its_value_means(code, message, error_type, value_name, value):
+    with pytest.raises(error_type) as raised:
+        raise_it(code, message=message)
+
+    error = raised.value
+
+    assert error.VALUE_NAME == value_name
+    assert getattr(error, value_name) == value
+    assert error.value == value
+
+
+def test_the_message_is_still_filled_in_with_the_value():
+    with pytest.raises(FloodWait) as raised:
+        raise_it(420, message="FLOOD_WAIT_42")
+
+    assert "Please wait 42 seconds before repeating the action." in str(raised.value)
+
+
+def test_an_error_that_carries_nothing_names_nothing():
+    with pytest.raises(PeerIdInvalid) as raised:
+        raise_it(400, message="PEER_ID_INVALID")
+
+    error = raised.value
+
+    assert error.VALUE_NAME == "value"
+    assert error.value is None
+
+
+def test_the_base_class_still_speaks_of_a_plain_value():
+    assert RPCError.VALUE_NAME == "value"
+    assert RPCError.MESSAGE == "{value}"
+    assert str(RPCError("something")).startswith("Telegram says: [None None] - something")
+
+
+def test_every_named_value_is_the_value_under_another_name():
+    errors = import_module("pyrogram.errors")
+    checked = 0
+
+    for table in exceptions.values():
+        for class_name in table.values():
+            error_type = getattr(errors, class_name)
+
+            # `value` is the attribute itself: a property of that name would shadow it.
+            assert error_type.VALUE_NAME != "value" or "value" not in vars(error_type)
+
+            if error_type.VALUE_NAME == "value":
+                continue
+
+            assert isinstance(vars(error_type)[error_type.VALUE_NAME], property)
+            assert getattr(error_type(42), error_type.VALUE_NAME) == 42
+
+            checked += 1
+
+    assert checked

--- a/tests/errors/test_named_values.py
+++ b/tests/errors/test_named_values.py
@@ -40,9 +40,9 @@ from pyrogram.errors import (
 from pyrogram.errors.exceptions.all import exceptions
 from tests.errors import RPC_NAME, raise_it
 
-# NOTE: Every class whose message names its value, counted once. One fewer than the 32 the tables
-#       produce: `FILE_MIGRATE_X` is listed under both 303 and 400, both rows compile to a class
-#       called `FileMigrate`, and `pyrogram.errors` keeps whichever was imported last.
+# Every class whose message names its value, counted once. One fewer than the 32 the tables produce:
+# `FILE_MIGRATE_X` is listed under both 303 and 400, both rows compile to a class called
+# `FileMigrate`, and `pyrogram.errors` keeps whichever was imported last.
 NAMED_ERRORS: Final[int] = 31
 
 

--- a/tests/errors/test_named_values.py
+++ b/tests/errors/test_named_values.py
@@ -153,6 +153,20 @@ def test_the_base_class_still_speaks_of_a_plain_value() -> None:
     assert str(RPCError("something")) == "Telegram says: [None None] - something "
 
 
+def test_no_message_asks_for_more_than_one_value() -> None:
+    errors: ModuleType = import_module("pyrogram.errors")
+
+    for table in exceptions.values():
+        for class_name in table.values():
+            error_type = getattr(errors, class_name)
+
+            # `raise_it()` reads one number out of a message and renders the message with it, so a
+            # second placeholder could never be filled in: `str.format()` would raise `KeyError`
+            # while building the error, and the caller would catch that instead of the error.
+            assert error_type.MESSAGE.count("{") <= 1
+            assert error_type.MESSAGE.count("{") == error_type.MESSAGE.count("}")
+
+
 def test_every_named_value_is_the_value_under_another_name() -> None:
     errors: ModuleType = import_module("pyrogram.errors")
     named: Set[Type[RPCError]] = set()

--- a/tests/errors/test_named_values.py
+++ b/tests/errors/test_named_values.py
@@ -18,27 +18,32 @@
 
 
 from importlib import import_module
+from types import ModuleType
+from typing import Final, Set, Type
 
 import pytest
 
-from pyrogram import raw
 from pyrogram.errors import (
+    AllowPaymentRequired,
+    AuthRestart,
+    EmailUnconfirmed,
     FilePartMissing,
+    FileReferenceExpired,
     FloodWait,
     PeerIdInvalid,
     PhoneMigrate,
     PremiumSubActiveUntil,
     PreviousChatImportActiveWaitMin,
-    RPCError
+    RPCError,
+    StoryLiveAlready
 )
 from pyrogram.errors.exceptions.all import exceptions
+from tests.errors import RPC_NAME, raise_it
 
-
-def raise_it(code, *, message):
-    RPCError.raise_it(
-        raw.types.RpcError(error_code=code, error_message=message),
-        raw.functions.messages.GetHistory
-    )
+# NOTE: Every class whose message names its value, counted once. One fewer than the 32 the tables
+#       produce: `FILE_MIGRATE_X` is listed under both 303 and 400, both rows compile to a class
+#       called `FileMigrate`, and `pyrogram.errors` keeps whichever was imported last.
+NAMED_ERRORS: Final[int] = 31
 
 
 @pytest.mark.parametrize(
@@ -46,7 +51,15 @@ def raise_it(code, *, message):
     [
         pytest.param(420, "FLOOD_WAIT_42", FloodWait, "seconds", 42, id="seconds"),
         pytest.param(303, "PHONE_MIGRATE_2", PhoneMigrate, "dc_id", 2, id="dc-id"),
-        pytest.param(400, "FILE_PART_3_MISSING", FilePartMissing, "part_number", 3, id="part-number"),
+        pytest.param(400, "FILE_PART_3_MISSING", FilePartMissing, "file_part", 3, id="file-part"),
+        pytest.param(
+            400,
+            "FILE_REFERENCE_1_EXPIRED",
+            FileReferenceExpired,
+            "index",
+            1,
+            id="index"
+        ),
         pytest.param(
             406,
             "PREVIOUS_CHAT_IMPORT_ACTIVE_WAIT_5MIN",
@@ -56,16 +69,47 @@ def raise_it(code, *, message):
             id="minutes"
         ),
         pytest.param(
+            400,
+            "EMAIL_UNCONFIRMED_6",
+            EmailUnconfirmed,
+            "code_length",
+            6,
+            id="code-length"
+        ),
+        pytest.param(
+            403,
+            "ALLOW_PAYMENT_REQUIRED_25",
+            AllowPaymentRequired,
+            "star_count",
+            25,
+            id="star-count"
+        ),
+        pytest.param(
+            400,
+            "STORY_LIVE_ALREADY_9",
+            StoryLiveAlready,
+            "story_id",
+            9,
+            id="story-id"
+        ),
+        pytest.param(
             420,
             "PREMIUM_SUB_ACTIVE_UNTIL_1755561600",
             PremiumSubActiveUntil,
             "until_date",
             1755561600,
             id="until-date"
-        )
+        ),
+        pytest.param(500, "AUTH_RESTART_7", AuthRestart, "debug_info", 7, id="debug-info")
     ]
 )
-def test_an_error_says_what_its_value_means(code, message, error_type, value_name, value):
+def test_an_error_says_what_its_value_means(
+    code: int,
+    message: str,
+    error_type: Type[RPCError],
+    value_name: str,
+    value: int
+) -> None:
     with pytest.raises(error_type) as raised:
         raise_it(code, message=message)
 
@@ -76,14 +120,17 @@ def test_an_error_says_what_its_value_means(code, message, error_type, value_nam
     assert error.value == value
 
 
-def test_the_message_is_still_filled_in_with_the_value():
+def test_the_message_is_still_filled_in_with_the_value() -> None:
     with pytest.raises(FloodWait) as raised:
         raise_it(420, message="FLOOD_WAIT_42")
 
-    assert "Please wait 42 seconds before repeating the action." in str(raised.value)
+    assert str(raised.value) == (
+        "Telegram says: [420 FLOOD_WAIT_X] - Please wait 42 seconds before repeating the action."
+        f' (caused by "{RPC_NAME}")'
+    )
 
 
-def test_an_error_that_carries_nothing_names_nothing():
+def test_an_error_that_carries_nothing_names_nothing() -> None:
     with pytest.raises(PeerIdInvalid) as raised:
         raise_it(400, message="PEER_ID_INVALID")
 
@@ -93,29 +140,35 @@ def test_an_error_that_carries_nothing_names_nothing():
     assert error.value is None
 
 
-def test_the_base_class_still_speaks_of_a_plain_value():
+def test_a_named_value_cannot_be_written_to() -> None:
+    error = FloodWait(42)
+
+    with pytest.raises(AttributeError):
+        error.seconds = 43
+
+
+def test_the_base_class_still_speaks_of_a_plain_value() -> None:
     assert RPCError.VALUE_NAME == "value"
     assert RPCError.MESSAGE == "{value}"
-    assert str(RPCError("something")).startswith("Telegram says: [None None] - something")
+    assert str(RPCError("something")) == "Telegram says: [None None] - something "
 
 
-def test_every_named_value_is_the_value_under_another_name():
-    errors = import_module("pyrogram.errors")
-    checked = 0
+def test_every_named_value_is_the_value_under_another_name() -> None:
+    errors: ModuleType = import_module("pyrogram.errors")
+    named: Set[Type[RPCError]] = set()
 
     for table in exceptions.values():
         for class_name in table.values():
             error_type = getattr(errors, class_name)
 
-            # `value` is the attribute itself: a property of that name would shadow it.
-            assert error_type.VALUE_NAME != "value" or "value" not in vars(error_type)
-
             if error_type.VALUE_NAME == "value":
+                # `value` is the attribute itself, so nothing may sit on the class under that name.
+                assert "value" not in vars(error_type)
                 continue
 
             assert isinstance(vars(error_type)[error_type.VALUE_NAME], property)
             assert getattr(error_type(42), error_type.VALUE_NAME) == 42
 
-            checked += 1
+            named.add(error_type)
 
-    assert checked
+    assert len(named) == NAMED_ERRORS


### PR DESCRIPTION
## What

Every parameterised error carries its parameter as `value`:

```python
except FloodWait as e:
    await asyncio.sleep(e.value)          # Seconds.

except FilePartMissing as e:
    await self.save_file(part=e.value)    # Part number.

except PhoneMigrate as e:
    await self.session.connect(e.value)   # DC id.
```

Three different things under one name, and the name says none of them. The tables already know
which is which — the message of each error spells it out — but that knowledge stops at the
docstring:

```
FLOOD_WAIT_X          Please wait {value} seconds before repeating the action.
PHONE_MIGRATE_X       The phone number a user is trying to use for authorization is associated to {value} DC.
FILE_PART_X_MISSING   Part {value} of the file is missing from storage.
```

## The change

The placeholder in a message is renamed to what the value means, and the compiler turns that name
into a read-only property alongside `value`:

```python
class FloodWait(Flood):
    """Please wait {seconds} seconds before repeating the action."""
    ID = "FLOOD_WAIT_X"
    """``str``: RPC Error ID"""
    MESSAGE = __doc__

    VALUE_NAME = "seconds"
    """``str``: Name of the property that holds this error's value"""

    @property
    def seconds(self) -> Optional[int]:
        """``Optional[int]``: Same as `value`, under the name this error's message gives it"""
        return self.value
```

so the three above read as what they are, and `e.value` keeps working everywhere:

```python
await asyncio.sleep(e.seconds)
await self.save_file(file_part=e.file_part)
await self.session.connect(e.dc_id)
```

`Optional[int]` rather than `int`: raised through `RPCError.raise_it()` the value is always the
number in the message, but an error constructed by hand — `FloodWait()` — carries `None`, and the
property is the same object as `value`.

`MESSAGE.format(value=value)` on the base class becomes `MESSAGE.format(**{VALUE_NAME: value})`,
with `VALUE_NAME = "value"` as the base default, so a message renders exactly as before. An error
whose message still says `{value}` gets no property — `value` is the attribute itself, and a
property of the same name would shadow it.

The 21 reads inside the library, across 15 files, are switched over, which is what makes
`session.py`'s flood handler read `amount = e.seconds` and the uploaders
`file_part=e.file_part`. Nothing outside the tables changes for callers: `value` is untouched,
`VALUE_NAME` is new.

## The names

32 rows get one, under 10 names. Where each comes from:

| name | rows | from |
| --- | --- | --- |
| `seconds` | 13 | Telethon's [`errors.csv`](https://github.com/LonamiWebs/Telethon/blob/v1.36.0/telethon_generator/data/errors.csv) — same name, same errors |
| `dc_id` | 8 | `auth.exportAuthorization.dc_id` in the schema, and what this library calls it everywhere else (`storage.dc_id`, `get_session(dc_id=...)`) |
| `index` | 4 | Telegram's own text for those errors: "the media file at index %d in the passed media array" |
| `file_part` | 1 | `upload.saveFilePart.file_part` — the argument the retry hands it straight back to |
| `code_length` | 1 | Telethon, same name |
| `minutes` | 1 | Telethon, same name |
| `star_count` | 1 | "This peer charges %d Telegram Stars per message"; TDLib spells every such number `*_star_count` |
| `story_id` | 1 | "This peer already has an active live story, and its ID is equal to %d" |
| `until_date` | 1 | "You already have a premium subscription active until unixtime %d"; `until_date` is the schema's word for this |
| `debug_info` | 1 | "Internal error (debug info %d), please repeat the method call" |

The quoted texts are Telegram's own descriptions, from
[`corefork.telegram.org/api/errors.json`](https://corefork.telegram.org/api/errors.json) (layer 227
at the time of writing), which is also where `mtcute` and MadelineProto take theirs from.

Four rows keep `{value}` and get no property:

- `RECAPTCHA_CHECK_X`, `APNS_VERIFY_CHECK_X` and `INTEGRITY_CHECK_CLASSIC_X` — the three
  verification errors. What they carry is a site key or a nonce, not a number, and a name would
  promise a shape the property cannot have.
- `INPUT_FETCH_ERROR_X` — it appears in no source I could find outside pyrogram forks: not in
  Telegram's list, not in Telethon's, not in TDLib. Its number may well be a constructor id, but
  the message does not say so and I would rather not promise it.

Prior art, for whoever reviews the names: Telethon derives the field name from the same
placeholder, and `mtcute`
[reads Telethon's csv](https://github.com/mtcute/mtcute/blob/master/packages/core/scripts/tl/fetch-errors.ts)
to build its own `_paramNames`. Telethon v2 went the other way and dropped the generated table
altogether — it synthesises an error class per name at runtime and keeps a plain `value`.

Where Telethon and this differ, it is to match the schema this library already speaks: `dc_id`
rather than `new_dc`/`dc` (it uses both, for the same thing), `file_part` rather than `which`.

## Tests

`tests/errors/test_named_values.py` — one case per name, all ten of them, each asserting that
`VALUE_NAME`, the property and `value` agree; the base class still renders `{value}`; a renamed
message still renders the whole line; an error without a parameter reports `None` under its own
name; and the property cannot be written to.

Plus two that walk the whole table rather than a sample. One: for every row, either `VALUE_NAME`
is `"value"` and nothing shadows the instance attribute, or `VALUE_NAME` names an actual `property`
that returns what was passed in — and the number of classes reached that way is pinned, so a name
lost to a typo in a message fails the suite instead of silently disappearing. Two: no message asks
for more than one value.

That second one is the invariant the whole scheme rests on. `raise_it()` reads a single number out
of a message and renders the message with it, so a second placeholder could never be filled in —
`str.format()` would raise `KeyError` while building the error, and the caller would catch that
instead of the error Telegram sent. It holds for all 937 rows today; the compiler now refuses to
build a message that breaks it:

```
ValueError: MADE_UP_X carries more than one placeholder: Wait {seconds} for {dc_id}.
```

`raise_it()` and the rpc name the tests raise through live in `tests/errors/__init__.py`, next
to the other test helpers this repo keeps in package `__init__.py` files.

`pytest tests`: 72 -> 190.

## Note

Merged `dev` in after #353 landed. That resolution is the only reason this branch touches
`tests/errors/test_rpc_error.py`: `FLOOD_WAIT_X` is now spelled `{seconds}`, so the attribute case
there expects that, and its copy of `raise_it()` is gone in favour of the one in
`tests/errors/__init__.py`.

Still touches `compiler/errors/compiler.py` and `compiler/errors/template/sub_class.txt`, which #357
also touches. If that one lands first I will rebase this.
