### PR TITLE
refactor(messages): cache the `messages.GetSplitRanges` result

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -409,6 +409,8 @@ class Client(Methods):
 
         self.me: Optional[User] = None
 
+        self.message_split_ranges: Optional[List["raw.base.MessageRange"]] = None
+
         self.message_cache = Cache(self.max_message_cache_size)
         self.topic_cache = Cache(self.max_topic_cache_size)
 
@@ -1530,6 +1532,11 @@ class Client(Methods):
         server_ts = msg_id / float(2**32)
         self._server_time_offset = server_ts - time.time()
         log.info(f"Time synced: offset={self._server_time_offset:.3f}s, server_time={utils.timestamp_to_datetime(server_ts)}")
+
+    async def get_message_split_ranges(self) -> List["raw.base.MessageRange"]:
+        if self.message_split_ranges is None:
+            self.message_split_ranges = await self.invoke(raw.functions.messages.GetSplitRanges())
+        return self.message_split_ranges
 
     def guess_mime_type(self, filename: Union[str, BytesIO]) -> Optional[str]:
         if isinstance(filename, BytesIO):

--- a/pyrogram/methods/messages/get_chat_history_count.py
+++ b/pyrogram/methods/messages/get_chat_history_count.py
@@ -56,7 +56,7 @@ class GetChatHistoryCount:
         peer = await self.resolve_peer(chat_id)
 
         # https://t.me/tdlibchat/189410
-        ranges = await self.invoke(raw.functions.messages.GetSplitRanges())
+        ranges = await self.get_message_split_ranges()
         total = 0
 
         for split_range in ranges:

--- a/pyrogram/methods/messages/search_messages_count.py
+++ b/pyrogram/methods/messages/search_messages_count.py
@@ -66,7 +66,7 @@ class SearchMessagesCount:
         from_id = await self.resolve_peer(from_user) if from_user else None
 
         # https://t.me/tdlibchat/189410
-        ranges = await self.invoke(raw.functions.messages.GetSplitRanges())
+        ranges = await self.get_message_split_ranges()
         total = 0
 
         for split_range in ranges:


### PR DESCRIPTION
`messages.getSplitRanges` returns the very same set of ranges for the whole
lifetime of a client, yet `get_chat_history_count` and `search_messages_count`
were requesting it from the server on every single call, adding a round trip to
each message count.

The result is now fetched once and reused: `Client.get_message_split_ranges`
memoizes it in `Client.message_split_ranges`, and both methods call the helper
instead of invoking the raw function themselves.

The cache lives as long as the client instance does, mirroring how `Client.me`
already behaves. It can be dropped by hand — `app.message_split_ranges = None` —
should a client ever be reused for another account.
